### PR TITLE
Support of (inlined) nested function calls for naive code generation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 build*/
 install*/
 
+# Meta project information
+bundle/mchbuild/*
+bundle/CMakeFiles/*
+
 # Shared library in source dir
 *.so
 *.dylib

--- a/scripts/travis/driver-install.sh
+++ b/scripts/travis/driver-install.sh
@@ -26,7 +26,6 @@ $CXX --version
 # Build dawn
 pushd "$(pwd)"
 
-export PYTHON_DIR=/opt/python/3.5.3
 
 cd bundle
 mkdir build
@@ -34,7 +33,6 @@ cd build
 cmake .. -DCMAKE_CXX_COMPILER="$CXX"                                                               \
          -DCMAKE_C_COMPILER="$CC"                                                                  \
          -DCMAKE_BUILD_TYPE="$CONFIG"                                                              \
-         -DPYTHON_EXECUTABLE="$PYTHON_DIR/bin/python3"                                             \
       || fatal_error "failed to configure"
 make -j2 protobuf || fatal_error "failed to build"
 

--- a/scripts/travis/driver-test.sh
+++ b/scripts/travis/driver-test.sh
@@ -32,7 +32,6 @@ $CXX --version
 # Build dawn
 pushd "$(pwd)"
 
-export PYTHON_DIR=/opt/python/3.5.3
 
 cd bundle
 mkdir build
@@ -42,7 +41,6 @@ build_dir=$(pwd)
 cmake .. -DCMAKE_CXX_COMPILER="$CXX"                                                               \
          -DCMAKE_C_COMPILER="$CC"                                                                  \
          -DCMAKE_BUILD_TYPE="$CONFIG"                                                              \
-         -DPYTHON_EXECUTABLE="$PYTHON_DIR/bin/python3"                                             \
          -DProtobuf_DIR=${build_dir}/protobuf-prefix/src/protobuf-build/lib/cmake/protobuf/        \
       || fatal_error "failed to configure"
 make -j2 || fatal_error "failed to build"

--- a/src/dawn/CodeGen/ASTCodeGenCXX.h
+++ b/src/dawn/CodeGen/ASTCodeGenCXX.h
@@ -73,8 +73,8 @@ public:
 
   /// @brief Mapping of VarDeclStmt and Var/FieldAccessExpr to their name
   /// @{
-  virtual const std::string& getName(const std::shared_ptr<Expr>& expr) const = 0;
-  virtual const std::string& getName(const std::shared_ptr<Stmt>& stmt) const = 0;
+  virtual std::string getName(const std::shared_ptr<Expr>& expr) const = 0;
+  virtual std::string getName(const std::shared_ptr<Stmt>& stmt) const = 0;
   /// @}
 
   /// @brief Convert builtin type to the corresponding C++ type

--- a/src/dawn/CodeGen/CMakeLists.txt
+++ b/src/dawn/CodeGen/CMakeLists.txt
@@ -17,6 +17,8 @@ mchbuild_add_library(
   SOURCES ASTCodeGenCXX.cpp
           ASTCodeGenCXX.h
           CodeGen.h
+          CodeGenProperties.cpp
+          CodeGenProperties.h
           CXXUtil.h
           CXXNaive/ASTStencilBody.cpp
           CXXNaive/ASTStencilBody.h

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
@@ -26,11 +26,9 @@ namespace codegen {
 namespace cxxnaive {
 
 ASTStencilBody::ASTStencilBody(const dawn::StencilInstantiation* stencilInstantiation,
-                               std::unordered_map<std::string, std::string> paramNameToType,
                                StencilContext stencilContext)
     : ASTCodeGenCXX(), instantiation_(stencilInstantiation), offsetPrinter_(",", "(", ")"),
-      currentFunction_(nullptr), paramNameToType_(paramNameToType), nestingOfStencilFunArgLists_(0),
-      stencilContext_(stencilContext) {}
+      currentFunction_(nullptr), nestingOfStencilFunArgLists_(0), stencilContext_(stencilContext) {}
 
 ASTStencilBody::~ASTStencilBody() {}
 
@@ -113,15 +111,15 @@ void ASTStencilBody::visit(const std::shared_ptr<StencilFunCallExpr>& expr) {
 
   ss_ << dawn::StencilFunctionInstantiation::makeCodeGenName(*stencilFun) << "(i,j,k";
 
-  int n = 0;
+  //  int n = 0;
+  ASTStencilFunctionParamVisitor fieldAccessVisitor(currentFunction_, instantiation_);
+
   for(auto& arg : expr->getArguments()) {
-    ASTStencilFunctionParamVisitor fieldAccessVisitor(paramNameToType_);
 
     arg->accept(fieldAccessVisitor);
-
-    ss_ << fieldAccessVisitor.getCodeAndResetStream();
-    ++n;
+    //    ++n;
   }
+  ss_ << fieldAccessVisitor.getCodeAndResetStream();
 
   nestingOfStencilFunArgLists_--;
   ss_ << ")";

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
@@ -34,14 +34,14 @@ ASTStencilBody::ASTStencilBody(const dawn::StencilInstantiation* stencilInstanti
 
 ASTStencilBody::~ASTStencilBody() {}
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromStmt(stmt));
   else
     return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromExpr(expr));
   else

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
@@ -157,8 +157,6 @@ void ASTStencilBody::visit(const std::shared_ptr<FieldAccessExpr>& expr) {
         argIndex = pp.first;
     }
 
-    auto accessOffset = expr->getOffset();
-
     if(currentFunction_->isArgStencilFunctionInstantiation(argIndex)) {
       StencilFunctionInstantiation& argStencilFn =
           *(currentFunction_->getFunctionInstantiationOfArgField(argIndex));

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
@@ -132,7 +132,7 @@ void ASTStencilBody::visit(const std::shared_ptr<VarAccessExpr>& expr) {
   int AccessID = getAccessID(expr);
 
   if(instantiation_->isGlobalVariable(AccessID)) {
-    ss_ << "globals::get()." << name;
+    ss_ << "globals::get()." << name << ".get_value()";
   } else {
     ss_ << name;
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
@@ -32,14 +32,14 @@ ASTStencilBody::ASTStencilBody(const dawn::StencilInstantiation* stencilInstanti
 
 ASTStencilBody::~ASTStencilBody() {}
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromStmt(stmt));
   else
     return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromExpr(expr));
   else

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
@@ -16,6 +16,7 @@
 #define DAWN_CODEGEN_CXXNAIVE_ASTSTENCILBODY_H
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
+#include "dawn/CodeGen/CodeGenProperties.h"
 #include "dawn/Optimizer/Interval.h"
 #include "dawn/Support/StringUtil.h"
 #include <stack>
@@ -28,10 +29,6 @@ class StencilFunctionInstantiation;
 
 namespace codegen {
 namespace cxxnaive {
-
-// @brief context of a stencil body
-// (pure stencil or a stencil function)
-enum class StencilContext { SC_Stencil, SC_StencilFunction };
 
 /// @brief ASTVisitor to generate C++ naive code for the stencil and stencil function bodies
 /// @ingroup cxxnaive

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
@@ -39,8 +39,6 @@ protected:
 
   /// The stencil function we are currently generating or NULL
   const StencilFunctionInstantiation* currentFunction_;
-  // map of stencil (or stencil function) parameter types to names
-  std::unordered_map<std::string, std::string> paramNameToType_;
 
   /// Nesting level of argument lists of stencil function *calls*
   int nestingOfStencilFunArgLists_;
@@ -72,9 +70,7 @@ public:
   using Base = ASTCodeGenCXX;
 
   /// @brief constructor
-  ASTStencilBody(const StencilInstantiation* stencilInstantiation,
-                 std::unordered_map<std::string, std::string> paramNameToType,
-                 StencilContext stencilContext);
+  ASTStencilBody(const StencilInstantiation* stencilInstantiation, StencilContext stencilContext);
 
   virtual ~ASTStencilBody();
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
@@ -104,8 +104,8 @@ public:
   void setCurrentStencilFunction(const StencilFunctionInstantiation* currentFunction);
 
   /// @brief Mapping of VarDeclStmt and Var/FieldAccessExpr to their name
-  const std::string& getName(const std::shared_ptr<Expr>& expr) const override;
-  const std::string& getName(const std::shared_ptr<Stmt>& stmt) const override;
+  std::string getName(const std::shared_ptr<Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<Stmt>& stmt) const override;
   int getAccessID(const std::shared_ptr<Expr>& expr) const;
 };
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
@@ -111,8 +111,8 @@ public:
   void setCurrentStencilFunction(const StencilFunctionInstantiation* currentFunction);
 
   /// @brief Mapping of VarDeclStmt and Var/FieldAccessExpr to their name
-  const std::string& getName(const std::shared_ptr<Expr>& expr) const override;
-  const std::string& getName(const std::shared_ptr<Stmt>& stmt) const override;
+  std::string getName(const std::shared_ptr<Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<Stmt>& stmt) const override;
   int getAccessID(const std::shared_ptr<Expr>& expr) const;
 };
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
@@ -53,7 +53,7 @@ void ASTStencilDesc::visit(const std::shared_ptr<StencilCallDeclStmt>& stmt) {
 
   std::string stencilName =
       codeGenProperties_.getStencilName(StencilContext::SC_Stencil, stencilID);
-  ss_ << "m_" << stencilName + "->run()";
+  ss_ << "m_" << stencilName + "->run();\n";
 }
 
 void ASTStencilDesc::visit(const std::shared_ptr<BoundaryConditionDeclStmt>& stmt) {

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
@@ -28,11 +28,11 @@ ASTStencilDesc::ASTStencilDesc(const StencilInstantiation* instantiation,
 
 ASTStencilDesc::~ASTStencilDesc() {}
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromExpr(expr));
 }
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
@@ -30,11 +30,11 @@ ASTStencilDesc::ASTStencilDesc(
 
 ASTStencilDesc::~ASTStencilDesc() {}
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromExpr(expr));
 }
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
@@ -22,11 +22,9 @@ namespace dawn {
 namespace codegen {
 namespace cxxnaive {
 
-ASTStencilDesc::ASTStencilDesc(
-    const StencilInstantiation* instantiation,
-    std::unordered_map<int, std::vector<std::string>> const& stencilIDToStencilNameMap)
-    : ASTCodeGenCXX(), instantiation_(instantiation),
-      stencilIDToStencilNameMap_(stencilIDToStencilNameMap) {}
+ASTStencilDesc::ASTStencilDesc(const StencilInstantiation* instantiation,
+                               CodeGenProperties const& codeGenProperties)
+    : ASTCodeGenCXX(), instantiation_(instantiation), codeGenProperties_(codeGenProperties) {}
 
 ASTStencilDesc::~ASTStencilDesc() {}
 
@@ -53,15 +51,9 @@ void ASTStencilDesc::visit(const std::shared_ptr<VerticalRegionDeclStmt>& stmt) 
 void ASTStencilDesc::visit(const std::shared_ptr<StencilCallDeclStmt>& stmt) {
   int stencilID = instantiation_->getStencilCallToStencilIDMap().find(stmt)->second;
 
-  for(const std::string& stencilName : stencilIDToStencilNameMap_.find(stencilID)->second) {
-
-    for(const auto& stencil : instantiation_->getStencils()) {
-
-      if(stencil->getStencilID() != stencilID)
-        continue;
-      ss_ << "m_" << stencilName + "->run()";
-    }
-  }
+  std::string stencilName =
+      codeGenProperties_.getStencilName(StencilContext::SC_Stencil, stencilID);
+  ss_ << "m_" << stencilName + "->run()";
 }
 
 void ASTStencilDesc::visit(const std::shared_ptr<BoundaryConditionDeclStmt>& stmt) {

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.h
@@ -60,8 +60,8 @@ public:
   virtual void visit(const std::shared_ptr<FieldAccessExpr>& expr) override;
   /// @}
 
-  const std::string& getName(const std::shared_ptr<Stmt>& stmt) const override;
-  const std::string& getName(const std::shared_ptr<Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<Stmt>& stmt) const override;
+  std::string getName(const std::shared_ptr<Expr>& expr) const override;
 };
 
 } // namespace cxxnaive

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.h
@@ -16,6 +16,7 @@
 #define DAWN_CODEGEN_CXXNAIVE_ASTSTENCILDESC_H
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
+#include "dawn/CodeGen/CodeGenProperties.h"
 #include "dawn/Support/StringUtil.h"
 #include <stack>
 #include <unordered_map>
@@ -33,14 +34,13 @@ class ASTStencilDesc : public ASTCodeGenCXX {
 protected:
   const StencilInstantiation* instantiation_;
 
-  std::unordered_map<int, std::vector<std::string>> stencilIDToStencilNameMap_;
+  const CodeGenProperties& codeGenProperties_;
 
 public:
   using Base = ASTCodeGenCXX;
 
-  ASTStencilDesc(
-      const StencilInstantiation* instantiation,
-      const std::unordered_map<int, std::vector<std::string>>& stencilIDToStencilNameMap);
+  ASTStencilDesc(const StencilInstantiation* instantiation,
+                 const CodeGenProperties& CodeGenProperties);
 
   virtual ~ASTStencilDesc();
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
@@ -37,6 +37,16 @@ void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<StencilFunArgEx
 
 void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<LiteralAccessExpr>& expr) {}
 
+void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<StencilFunCallExpr>& expr) {
+  for(auto& arg : expr->getArguments()) {
+    ASTStencilFunctionParamVisitor fieldAccessVisitor(paramNameToType_);
+
+    arg->accept(fieldAccessVisitor);
+
+    ss_ << fieldAccessVisitor.getCodeAndResetStream();
+  }
+}
+
 void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<FieldAccessExpr>& expr) {
 
   if(!paramNameToType_.count(expr->getName()))

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
@@ -26,10 +26,25 @@ namespace codegen {
 namespace cxxnaive {
 
 ASTStencilFunctionParamVisitor::ASTStencilFunctionParamVisitor(
-    std::unordered_map<std::string, std::string> paramNameToType)
-    : paramNameToType_(paramNameToType) {}
+    StencilFunctionInstantiation const* function, StencilInstantiation const* instantiation)
+    : instantiation_(instantiation), currentFunction_(function) {}
 
 ASTStencilFunctionParamVisitor::~ASTStencilFunctionParamVisitor() {}
+
+std::string ASTStencilFunctionParamVisitor::getName(const std::shared_ptr<Expr>& expr) const {
+
+  if(currentFunction_)
+    return currentFunction_->getNameFromAccessID(getAccessID(expr));
+  else
+    return instantiation_->getNameFromAccessID(getAccessID(expr));
+}
+
+int ASTStencilFunctionParamVisitor::getAccessID(const std::shared_ptr<Expr>& expr) const {
+  if(currentFunction_)
+    return currentFunction_->getAccessIDFromExpr(expr);
+  else
+    return instantiation_->getAccessIDFromExpr(expr);
+}
 
 void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<VarAccessExpr>& expr) {}
 
@@ -38,24 +53,22 @@ void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<StencilFunArgEx
 void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<LiteralAccessExpr>& expr) {}
 
 void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<StencilFunCallExpr>& expr) {
+
   for(auto& arg : expr->getArguments()) {
-    ASTStencilFunctionParamVisitor fieldAccessVisitor(paramNameToType_);
-
-    arg->accept(fieldAccessVisitor);
-
-    ss_ << fieldAccessVisitor.getCodeAndResetStream();
+    arg->accept(*this);
   }
 }
 
 void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<FieldAccessExpr>& expr) {
 
-  if(!paramNameToType_.count(expr->getName()))
-    DAWN_ASSERT_MSG(0, "param of stencil function call not found");
+  std::string fieldName = (currentFunction_)
+                              ? currentFunction_->getOriginalNameFromCallerAccessID(
+                                    currentFunction_->getAccessIDFromExpr(expr))
+                              : getName(expr);
 
-  ss_ << ",param_wrapper<" << c_gt() << "data_view<" << paramNameToType_[expr->getName()] << ">>("
-      << expr->getName() << ","
+  ss_ << ",param_wrapper<decltype(" << fieldName << ")>(" << fieldName << ","
       << "std::array<int, 3>{" << RangeToString(", ", "", "")(expr->getOffset())
-      << "}+" + expr->getName() + "_offsets)";
+      << "}+" + fieldName + "_offsets)";
 }
 
 std::string ASTStencilFunctionParamVisitor::getCodeAndResetStream() {

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
@@ -52,7 +52,7 @@ void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<FieldAccessExpr
   if(!paramNameToType_.count(expr->getName()))
     DAWN_ASSERT_MSG(0, "param of stencil function call not found");
 
-  ss_ << ",ParamWrapper<" << c_gt() << "data_view<" << paramNameToType_[expr->getName()] << ">>("
+  ss_ << ",param_wrapper<" << c_gt() << "data_view<" << paramNameToType_[expr->getName()] << ">>("
       << expr->getName() << ","
       << "std::array<int, 3>{" << RangeToString(", ", "", "")(expr->getOffset())
       << "}+" + expr->getName() + "_offsets)";

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
@@ -44,7 +44,8 @@ void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<FieldAccessExpr
 
   ss_ << ",ParamWrapper<" << c_gt() << "data_view<" << paramNameToType_[expr->getName()] << ">>("
       << expr->getName() << ","
-      << "std::array<int, 3>{" << RangeToString(", ", "", "")(expr->getOffset()) << "})";
+      << "std::array<int, 3>{" << RangeToString(", ", "", "")(expr->getOffset())
+      << "}+" + expr->getName() + "_offsets)";
 }
 
 std::string ASTStencilFunctionParamVisitor::getCodeAndResetStream() {

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h
@@ -33,17 +33,23 @@ namespace cxxnaive {
 /// @ingroup cxxnaive
 class ASTStencilFunctionParamVisitor : public ASTVisitorDisabled, public NonCopyable {
 protected:
-  std::unordered_map<std::string, std::string> paramNameToType_;
+  const StencilInstantiation* instantiation_;
+  const StencilFunctionInstantiation* currentFunction_;
   /// Underlying stream
   std::stringstream ss_;
 
 public:
   using Base = ASTVisitorDisabled;
 
-  ASTStencilFunctionParamVisitor(std::unordered_map<std::string, std::string> paramNameToType);
+  ASTStencilFunctionParamVisitor(StencilFunctionInstantiation const* function,
+                                 StencilInstantiation const* instantiation);
   virtual ~ASTStencilFunctionParamVisitor();
 
   std::string getCodeAndResetStream();
+
+  std::string getName(const std::shared_ptr<Expr>& expr) const;
+
+  int getAccessID(const std::shared_ptr<Expr>& expr) const;
 
   /// @name Expression implementation
   /// @{

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h
@@ -22,11 +22,11 @@
 #include <unordered_map>
 
 namespace dawn {
-namespace codegen {
-namespace cxxnaive {
-
 class StencilInstantiation;
 class StencilFunctionInstantiation;
+
+namespace codegen {
+namespace cxxnaive {
 
 /// @brief ASTVisitor to generate C++ naive backend code for the parameters of the stencil function
 /// calls
@@ -51,6 +51,7 @@ public:
   virtual void visit(const std::shared_ptr<StencilFunArgExpr>& expr) override;
   virtual void visit(const std::shared_ptr<LiteralAccessExpr>& expr) override;
   virtual void visit(const std::shared_ptr<FieldAccessExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<StencilFunCallExpr>& expr) override;
   /// @}
 };
 

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -137,7 +137,7 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
                                 std::to_string(m) + ">> pw_" + paramName);
       }
 
-      ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation, paramNameToType,
+      ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation,
                                            StencilContext::SC_StencilFunction);
 
       stencilFunMethod.startBody();
@@ -150,7 +150,6 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
                          << paramName << " = pw_" << paramName << ".dview_;";
         stencilFunMethod << "auto " << paramName << "_offsets = pw_" << paramName << ".offsets_;";
       }
-
       stencilBodyCXXVisitor.setCurrentStencilFunction(stencilFun.get());
       stencilBodyCXXVisitor.setIndent(stencilFunMethod.getIndent());
       for(const auto& statementAccessesPair : stencilFun->getStatementAccessesPairs()) {
@@ -220,8 +219,7 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
       paramNameToType.emplace((*fieldIt).Name, c_gtc().str() + "storage_t");
     }
 
-    ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation, paramNameToType,
-                                         StencilContext::SC_Stencil);
+    ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation, StencilContext::SC_Stencil);
 
     StencilClass.addComment("//Members");
 
@@ -318,7 +316,6 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
                             // Generate Do-Method
                             for(const auto& doMethodPtr : stage.getDoMethods()) {
                               const DoMethod& doMethod = *doMethodPtr;
-
                               if(!doMethod.getInterval().overlaps(interval))
                                 continue;
                               for(const auto& statementAccessesPair :

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -66,32 +66,8 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
 
   Namespace cxxnaiveNamespace("cxxnaive", ssSW);
 
-  MemberFunction arraysumop = createFunction("std::array<int,N>", "operator+", ssSW, "size_t N");
-  arraysumop.addArg("std::array<int, N> const& a");
-  arraysumop.addArg("std::array<int, N> const& b");
-  arraysumop.addStatement("std::array<int, N> res");
-  arraysumop.addBlockStatement("for(size_t i =0; i < N; ++i)",
-                               [&]() { arraysumop.addStatement("res[i] = a[i]+b[i]"); });
-  arraysumop.addStatement("return res");
-  arraysumop.commit();
-
   Class StencilWrapperClass(stencilInstantiation->getName(), ssSW);
   StencilWrapperClass.changeAccessibility("private");
-
-  Structure paramWrapper = StencilWrapperClass.addStruct("ParamWrapper", "class DataView");
-  paramWrapper.addMember("DataView", "dview_");
-  paramWrapper.addMember("std::array<int, DataView::storage_info_t::ndims>", "offsets_");
-
-  auto pwClassCtr = paramWrapper.addConstructor();
-
-  pwClassCtr.addArg("DataView dview");
-  pwClassCtr.addArg("std::array<int, DataView::storage_info_t::ndims> offsets");
-  pwClassCtr.addInit("dview_(dview)");
-  pwClassCtr.addInit("offsets_(offsets)");
-
-  pwClassCtr.commit();
-
-  paramWrapper.commit();
 
   // Generate stencils
   auto& stencils = stencilInstantiation->getStencils();

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -129,11 +129,11 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
         std::string paramName = stencilFun->getOriginalNameFromCallerAccessID(fields[m].AccessID);
         paramNameToType.emplace(paramName, stencilFnTemplates[m]);
 
-        // each parameter being passed to a stencil function, is wrapped around the ParamWrapper
+        // each parameter being passed to a stencil function, is wrapped around the param_wrapper
         // that contains the storage and the offset, in order to resolve offset passed to the
         // storage during the function call. For example:
         // fn_call(v(i+1), v(j-1))
-        stencilFunMethod.addArg("ParamWrapper<" + c_gt() + "data_view<StorageType" +
+        stencilFunMethod.addArg("param_wrapper<" + c_gt() + "data_view<StorageType" +
                                 std::to_string(m) + ">> pw_" + paramName);
       }
 

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -264,8 +264,12 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
     // Run-Method
     //
     MemberFunction StencilDoMethod = StencilClass.addMemberFunction("virtual void", "run", "");
+    StencilDoMethod.startBody();
 
     for(const auto& multiStagePtr : stencil.getMultiStages()) {
+
+      StencilDoMethod.ss() << "{";
+
       const MultiStage& multiStage = *multiStagePtr;
 
       // create all the data views
@@ -320,6 +324,7 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
               }
             });
       }
+      StencilDoMethod.ss() << "}";
     }
     StencilDoMethod.commit();
   }

--- a/src/dawn/CodeGen/CXXUtil.h
+++ b/src/dawn/CodeGen/CXXUtil.h
@@ -670,6 +670,14 @@ struct Struct : public Structure {
       : Structure("struct", name, s, templateName) {}
 };
 
+inline MemberFunction createFunction(const Twine& returnType, const Twine& funcName,
+                                     std::stringstream& s,
+                                     const Twine& templateName = Twine::createNull()) {
+  if(!templateName.isTriviallyEmpty())
+    s << "template<" << templateName.str() << ">\n";
+  return MemberFunction(returnType, funcName, s);
+}
+
 auto c_gt = []() { return Twine("gridtools::"); };
 auto c_gtc = []() { return Twine("gridtools::clang::"); };
 auto c_gt_enum = []() { return Twine("gridtools::enumtype::"); };

--- a/src/dawn/CodeGen/CXXUtil.h
+++ b/src/dawn/CodeGen/CXXUtil.h
@@ -259,6 +259,24 @@ struct Using : public Statement {
 };
 
 //===------------------------------------------------------------------------------------------===//
+//     Namespace
+//===------------------------------------------------------------------------------------------===//
+/// @brief Definition of a `namespace`
+/// @ingroup codegen
+struct Namespace {
+  const Twine name_;
+  std::stringstream& s_;
+
+  ~Namespace() {}
+  /// @brief Add `namespace`
+  Namespace(const Twine& name, std::stringstream& s) : name_(name), s_(s) {
+    s_ << "namespace " << name_ << "{" << std::endl;
+  }
+
+  void commit() { s_ << "} // namespace " << name_ << std::endl; }
+};
+
+//===------------------------------------------------------------------------------------------===//
 //     Function
 //===------------------------------------------------------------------------------------------===//
 

--- a/src/dawn/CodeGen/CXXUtil.h
+++ b/src/dawn/CodeGen/CXXUtil.h
@@ -670,14 +670,6 @@ struct Struct : public Structure {
       : Structure("struct", name, s, templateName) {}
 };
 
-inline MemberFunction createFunction(const Twine& returnType, const Twine& funcName,
-                                     std::stringstream& s,
-                                     const Twine& templateName = Twine::createNull()) {
-  if(!templateName.isTriviallyEmpty())
-    s << "template<" << templateName.str() << ">\n";
-  return MemberFunction(returnType, funcName, s);
-}
-
 auto c_gt = []() { return Twine("gridtools::"); };
 auto c_gtc = []() { return Twine("gridtools::clang::"); };
 auto c_gt_enum = []() { return Twine("gridtools::enumtype::"); };

--- a/src/dawn/CodeGen/CodeGenProperties.cpp
+++ b/src/dawn/CodeGen/CodeGenProperties.cpp
@@ -1,0 +1,73 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "dawn/CodeGen/CodeGenProperties.h"
+#include <memory>
+
+namespace dawn {
+namespace codegen {
+
+void CodeGenProperties::insertParam(const size_t paramPosition, std::string paramName,
+                                    std::string paramType) {
+  DAWN_ASSERT_MSG(!paramPositionIdxToName_.count(paramPosition), "parameter already inserted");
+  paramPositionIdxToName_[paramPosition] = paramName;
+  DAWN_ASSERT_MSG(!paramNameToType_.count(paramName), "parameter already inserted");
+  paramNameToType_[paramName] = paramType;
+}
+
+std::string CodeGenProperties::getParamType(const std::string paramName) const {
+  DAWN_ASSERT_MSG(paramNameToType_.count(paramName),
+                  std::string("parameter " + paramName + " not found").c_str());
+  return paramNameToType_.at(paramName);
+}
+
+std::unordered_map<std::string, std::shared_ptr<StencilProperties>>&
+CodeGenProperties::stencilProperties(StencilContext context) {
+  return stencilContextProperties_[static_cast<int>(context)].stencilProps_;
+}
+
+std::shared_ptr<StencilProperties>
+CodeGenProperties::insertStencil(StencilContext context, const int id, const std::string name) {
+  return insertStencil(stencilContextProperties_[static_cast<int>(context)], id, name);
+}
+
+std::shared_ptr<StencilProperties> CodeGenProperties::getStencilProperties(StencilContext context,
+                                                                           const std::string name) {
+  DAWN_ASSERT_MSG(stencilContextProperties_[static_cast<int>(context)].stencilProps_.count(name),
+                  "stencil name not found");
+  return stencilContextProperties_[static_cast<int>(context)].stencilProps_[name];
+}
+
+std::shared_ptr<StencilProperties> CodeGenProperties::getStencilProperties(StencilContext context,
+                                                                           const int id) {
+  return getStencilProperties(context, getStencilName(context, id));
+}
+
+std::string CodeGenProperties::getStencilName(StencilContext context, const size_t id) const {
+  DAWN_ASSERT_MSG(stencilContextProperties_[static_cast<int>(context)].stencilIDToName_.count(id),
+                  "id of stencil not found");
+  return stencilContextProperties_[static_cast<int>(context)].stencilIDToName_.at(id);
+}
+
+std::shared_ptr<StencilProperties> CodeGenProperties::insertStencil(Impl& impl, const size_t id,
+                                                                    const std::string name) {
+  DAWN_ASSERT_MSG(!impl.stencilIDToName_.count(id), "stencil already inserted");
+  impl.stencilIDToName_[id] = name;
+  DAWN_ASSERT_MSG(!impl.stencilProps_.count(name), "stencil already inserted");
+  impl.stencilProps_[name] = std::make_shared<StencilProperties>(id, name);
+  return impl.stencilProps_[name];
+}
+
+} // namespace codegen
+} // namespace dawn

--- a/src/dawn/CodeGen/CodeGenProperties.h
+++ b/src/dawn/CodeGen/CodeGenProperties.h
@@ -1,0 +1,69 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#ifndef DAWN_CODEGEN_CODEGENPROPERTIES_H
+#define DAWN_CODEGEN_CODEGENPROPERTIES_H
+
+#include "dawn/Support/Assert.h"
+#include <memory>
+#include <unordered_map>
+
+namespace dawn {
+namespace codegen {
+// @brief context of a stencil body
+// (pure stencil or a stencil function)
+enum class StencilContext { SC_Stencil = 0, SC_StencilFunction };
+
+struct StencilProperties {
+  std::unordered_map<std::string, std::string> paramNameToType_;
+  const int id_;
+  const std::string name_;
+  StencilProperties(const int id, const std::string name) : id_(id), name_(name) {}
+};
+
+struct CodeGenProperties {
+  struct Impl {
+    std::unordered_map<std::string, std::shared_ptr<StencilProperties>> stencilProps_;
+    std::unordered_map<size_t, std::string> stencilIDToName_;
+  };
+
+  std::unordered_map<std::string, std::string> paramNameToType_;
+  std::unordered_map<size_t, std::string> paramPositionIdxToName_;
+
+  std::array<Impl, 2> stencilContextProperties_;
+
+  void insertParam(const size_t paramPosition, std::string paramName, std::string paramType);
+
+  std::string getParamType(const std::string paramName) const;
+
+  std::unordered_map<std::string, std::shared_ptr<StencilProperties>>&
+  stencilProperties(StencilContext context);
+
+  std::shared_ptr<StencilProperties> insertStencil(StencilContext context, const int id,
+                                                   const std::string name);
+
+  std::shared_ptr<StencilProperties> getStencilProperties(StencilContext context,
+                                                          const std::string name);
+
+  std::shared_ptr<StencilProperties> getStencilProperties(StencilContext context, const int id);
+
+  std::string getStencilName(StencilContext context, const size_t id) const;
+
+private:
+  std::shared_ptr<StencilProperties> insertStencil(Impl& impl, const size_t id,
+                                                   const std::string name);
+};
+} // namespace codegen
+} // namespace dawn
+#endif

--- a/src/dawn/CodeGen/CodeGenProperties.h
+++ b/src/dawn/CodeGen/CodeGenProperties.h
@@ -25,6 +25,8 @@ namespace codegen {
 // (pure stencil or a stencil function)
 enum class StencilContext { SC_Stencil = 0, SC_StencilFunction };
 
+/// @brief struct to store properties of a stencil for code generation
+/// @ingroup codegen
 struct StencilProperties {
   std::unordered_map<std::string, std::string> paramNameToType_;
   const int id_;
@@ -32,32 +34,46 @@ struct StencilProperties {
   StencilProperties(const int id, const std::string name) : id_(id), name_(name) {}
 };
 
-struct CodeGenProperties {
+/// @brief global metadata and properties of stencils needed for code generation
+/// @ingroup codegen
+class CodeGenProperties {
   struct Impl {
     std::unordered_map<std::string, std::shared_ptr<StencilProperties>> stencilProps_;
     std::unordered_map<size_t, std::string> stencilIDToName_;
   };
 
+  // map of parameter name to its type
   std::unordered_map<std::string, std::string> paramNameToType_;
+  // map of parameter position to its name
   std::unordered_map<size_t, std::string> paramPositionIdxToName_;
 
+  // array stencil properties. The elements of the array corresponds to
+  // SC_Stencil and SC_StencilFunction
   std::array<Impl, 2> stencilContextProperties_;
 
+public:
+  /// @brief insert a parameter in the mapping data structures
   void insertParam(const size_t paramPosition, std::string paramName, std::string paramType);
 
+  /// @brief get the type associate to parameter with name paramName
   std::string getParamType(const std::string paramName) const;
 
+  /// @brief stencil properties map getter
   std::unordered_map<std::string, std::shared_ptr<StencilProperties>>&
   stencilProperties(StencilContext context);
 
+  /// @brief insert a new stencil properties
   std::shared_ptr<StencilProperties> insertStencil(StencilContext context, const int id,
                                                    const std::string name);
 
+  /// @brief stencil properties getter
   std::shared_ptr<StencilProperties> getStencilProperties(StencilContext context,
                                                           const std::string name);
 
+  /// @brief stencil properties getter
   std::shared_ptr<StencilProperties> getStencilProperties(StencilContext context, const int id);
 
+  /// @brief stencil name getter
   std::string getStencilName(StencilContext context, const size_t id) const;
 
 private:

--- a/src/dawn/CodeGen/GridTools/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/GridTools/ASTStencilBody.cpp
@@ -24,22 +24,21 @@ namespace dawn {
 namespace codegen {
 namespace gt {
 
-ASTStencilBody::ASTStencilBody(
-    const StencilInstantiation* stencilInstantiation,
-    const std::unordered_map<Interval, std::string>& intervalToNameMap)
+ASTStencilBody::ASTStencilBody(const StencilInstantiation* stencilInstantiation,
+                               const std::unordered_map<Interval, std::string>& intervalToNameMap)
     : ASTCodeGenCXX(), instantiation_(stencilInstantiation), intervalToNameMap_(intervalToNameMap),
       offsetPrinter_(",", "(", ")"), currentFunction_(nullptr), nestingOfStencilFunArgLists_(0) {}
 
 ASTStencilBody::~ASTStencilBody() {}
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromStmt(stmt));
   else
     return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromExpr(expr));
   else
@@ -96,21 +95,13 @@ void ASTStencilBody::visit(const std::shared_ptr<IfStmt>& stmt) { Base::visit(st
 //     Expr
 //===------------------------------------------------------------------------------------------===//
 
-void ASTStencilBody::visit(const std::shared_ptr<UnaryOperator>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<UnaryOperator>& expr) { Base::visit(expr); }
 
-void ASTStencilBody::visit(const std::shared_ptr<BinaryOperator>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<BinaryOperator>& expr) { Base::visit(expr); }
 
-void ASTStencilBody::visit(const std::shared_ptr<AssignmentExpr>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<AssignmentExpr>& expr) { Base::visit(expr); }
 
-void ASTStencilBody::visit(const std::shared_ptr<TernaryOperator>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<TernaryOperator>& expr) { Base::visit(expr); }
 
 void ASTStencilBody::visit(const std::shared_ptr<FunCallExpr>& expr) { Base::visit(expr); }
 
@@ -160,9 +151,7 @@ void ASTStencilBody::visit(const std::shared_ptr<VarAccessExpr>& expr) {
   }
 }
 
-void ASTStencilBody::visit(const std::shared_ptr<LiteralAccessExpr>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<LiteralAccessExpr>& expr) { Base::visit(expr); }
 
 void ASTStencilBody::visit(const std::shared_ptr<FieldAccessExpr>& expr) {
   if(!nestingOfStencilFunArgLists_)

--- a/src/dawn/CodeGen/GridTools/ASTStencilBody.h
+++ b/src/dawn/CodeGen/GridTools/ASTStencilBody.h
@@ -80,8 +80,8 @@ public:
   void setCurrentStencilFunction(const StencilFunctionInstantiation* currentFunction);
 
   /// @brief Mapping of VarDeclStmt and Var/FieldAccessExpr to their name
-  const std::string& getName(const std::shared_ptr<Expr>& expr) const override;
-  const std::string& getName(const std::shared_ptr<Stmt>& stmt) const override;
+  std::string getName(const std::shared_ptr<Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<Stmt>& stmt) const override;
   int getAccessID(const std::shared_ptr<Expr>& expr) const;
 };
 

--- a/src/dawn/CodeGen/GridTools/ASTStencilDesc.cpp
+++ b/src/dawn/CodeGen/GridTools/ASTStencilDesc.cpp
@@ -30,11 +30,11 @@ ASTStencilDesc::ASTStencilDesc(
 
 ASTStencilDesc::~ASTStencilDesc() {}
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromExpr(expr));
 }
 

--- a/src/dawn/CodeGen/GridTools/ASTStencilDesc.h
+++ b/src/dawn/CodeGen/GridTools/ASTStencilDesc.h
@@ -71,8 +71,8 @@ public:
   virtual void visit(const std::shared_ptr<FieldAccessExpr>& expr) override;
   /// @}
 
-  const std::string& getName(const std::shared_ptr<Stmt>& stmt) const override;
-  const std::string& getName(const std::shared_ptr<Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<Stmt>& stmt) const override;
+  std::string getName(const std::shared_ptr<Expr>& expr) const override;
 };
 
 } // namespace gt

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -334,7 +334,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
           // Generate placeholder mapping of the field in `make_stage`
           ssMS << "p_" << paramName << "()"
-               << ((stage.hasGlobalVariables() && (accessorIdx == fields.size() - 1)) ? "" : ", ");
+               << ((!stage.hasGlobalVariables() && (accessorIdx == fields.size() - 1)) ? "" : ", ");
 
           arglist.push_back(std::move(paramName));
         }

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -88,6 +88,8 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
   std::stringstream ssSW, ssMS, tss;
 
+  Namespace gridtoolsNamespace("gridtools", ssSW);
+
   // K-Cache branch changes the signature of Do-Methods
   const char* DoMethodArg = "Evaluation& eval";
 
@@ -631,6 +633,8 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
   StencilWrapperClass.commit();
 
+  gridtoolsNamespace.commit();
+
   // Remove trailing ';' as this is retained by Clang's Rewriter
   std::string str = ssSW.str();
   str[str.size() - 2] = ' ';
@@ -646,6 +650,8 @@ std::string GTCodeGen::generateGlobals(const SIR* Sir) {
     return "";
 
   std::stringstream ss;
+
+  Namespace gridtoolsNamespace("gridtools", ss);
 
   std::string StructName = "globals";
   std::string BaseName = "gridtools::clang::globals_impl<" + StructName + ">";
@@ -681,6 +687,8 @@ std::string GTCodeGen::generateGlobals(const SIR* Sir) {
   codegen::Statement(ss) << "template<> " << StructName << "* " << BaseName
                          << "::s_instance = nullptr";
 
+  gridtoolsNamespace.commit();
+
   // Remove trailing ';' as this is retained by Clang's Rewriter
   std::string str = ss.str();
   str[str.size() - 2] = ' ';
@@ -714,8 +722,6 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
   };
 
   ppDefines.push_back(makeDefine("GRIDTOOLS_CLANG_GENERATED", 1));
-  ppDefines.push_back(
-      makeDefine("GRIDTOOLS_CLANG_HALO_EXTEND", context_->getOptions().MaxHaloPoints));
   ppDefines.push_back(makeIfNotDefined("BOOST_RESULT_OF_USE_TR1", 1));
   ppDefines.push_back(makeIfNotDefined("BOOST_NO_CXX11_DECLTYPE", 1));
 

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -157,7 +157,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
     // Generate code for members of the stencil
     StencilClass.addComment("Members");
-    StencilClass.addMember("std::shared_ptr< gridtools::stencil >", "m_stencil");
+    StencilClass.addMember("std::shared_ptr< gridtools::stencil<gridtools::notype> >", "m_stencil");
     StencilClass.addMember(Twine("std::unique_ptr< grid_") + StencilName + ">", "m_grid");
 
     //
@@ -513,7 +513,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     dtor.commit();
 
     // Generate stencil getter
-    StencilClass.addMemberFunction("gridtools::stencil*", "get_stencil")
+    StencilClass.addMemberFunction("gridtools::stencil<gridtools::notype>*", "get_stencil")
         .addStatement("return m_stencil.get()");
   }
 
@@ -630,11 +630,12 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
   RunMethod.commit();
 
   // Generate stencil getter
-  StencilWrapperClass.addMemberFunction("std::vector<gridtools::stencil*>", "get_stencils")
-      .addStatement("return " + RangeToString(", ", "std::vector<gridtools::stencil*>({",
-                                              "})")(stencilMembers, [](const std::string& member) {
-                      return member + ".get_stencil()";
-                    }));
+  StencilWrapperClass
+      .addMemberFunction("std::vector<gridtools::stencil<gridtools::notype>*>", "get_stencils")
+      .addStatement(
+          "return " +
+          RangeToString(", ", "std::vector<gridtools::stencil<gridtools::notype>*>({", "})")(
+              stencilMembers, [](const std::string& member) { return member + ".get_stencil()"; }));
 
   // Generate name getter
   StencilWrapperClass.addMemberFunction("const char*", "get_name")

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -206,6 +206,18 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
           arglist.push_back(std::move(paramName));
         }
 
+        // Global accessor declaration
+        for(auto accessID : stencilFun->getAccessIDSetGlobalVariables()) {
+          std::string paramName = stencilFun->getNameFromAccessID(accessID);
+          StencilFunStruct.addTypeDef(paramName)
+              .addType(c_gt() + "global_accessor")
+              .addTemplate(Twine(accessorID))
+              .addTemplate(c_gt_enum() + "in");
+          accessorID++;
+
+          arglist.push_back(std::move(paramName));
+        }
+
         // Generate arglist
         StencilFunStruct.addTypeDef("arg_list").addType("boost::mpl::vector").addTemplates(arglist);
         mplContainerMaxSize_ = std::max(mplContainerMaxSize_, arglist.size());
@@ -321,16 +333,14 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
           // Generate placeholder mapping of the field in `make_stage`
           ssMS << "p_" << paramName << "()"
-               << ((stage.getGlobalVariables().empty() && (accessorIdx == fields.size() - 1))
-                       ? ""
-                       : ", ");
+               << ((stage.hasGlobalVariables() && (accessorIdx == fields.size() - 1)) ? "" : ", ");
 
           arglist.push_back(std::move(paramName));
         }
 
         // Global accessor declaration
-        std::size_t maxAccessors = fields.size() + stage.getGlobalVariables().size();
-        for(int AccessID : stage.getGlobalVariables()) {
+        std::size_t maxAccessors = fields.size() + stage.getAllGlobalVariables().size();
+        for(int AccessID : stage.getAllGlobalVariables()) {
           std::string paramName = stencilInstantiation->getNameFromAccessID(AccessID);
 
           StageStruct.addTypeDef(paramName)

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -213,8 +213,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
           std::string paramName = stencilFun->getNameFromAccessID(accessID);
           StencilFunStruct.addTypeDef(paramName)
               .addType(c_gt() + "global_accessor")
-              .addTemplate(Twine(accessorID))
-              .addTemplate(c_gt_enum() + "in");
+              .addTemplate(Twine(accessorID));
           accessorID++;
 
           arglist.push_back(std::move(paramName));
@@ -347,8 +346,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
           StageStruct.addTypeDef(paramName)
               .addType(c_gt() + "global_accessor")
-              .addTemplate(Twine(accessorIdx))
-              .addTemplate(c_gt_enum() + "inout");
+              .addTemplate(Twine(accessorIdx));
           accessorIdx++;
 
           // Generate placeholder mapping of the field in `make_stage`

--- a/src/dawn/Optimizer/Interval.h
+++ b/src/dawn/Optimizer/Interval.h
@@ -42,6 +42,8 @@ class Interval {
   int upperOffset_;
 
 public:
+  enum class Bound { upper = 0, lower };
+
   /// @name Constructors and Assignment
   /// @{
   Interval(int lowerLevel, int upperLevel, int lowerOffset = 0, int upperOffset = 0)
@@ -62,6 +64,18 @@ public:
   int upperLevel() const { return upperLevel_; }
   int lowerOffset() const { return lowerOffset_; }
   int upperOffset() const { return upperOffset_; }
+
+  int offset(const Bound bound) const {
+    return (bound == Bound::lower) ? lowerOffset() : upperOffset();
+  }
+  int level(const Bound bound) const {
+    return (bound == Bound::lower) ? lowerLevel() : upperLevel();
+  }
+
+  /// @brief Get the bound of the Interval (i.e `level + offset`)
+  inline int bound(const Bound bound) const {
+    return (bound == Bound::lower) ? lowerBound() : upperBound();
+  }
 
   /// @brief Get the lower bound of the Interval (i.e `lowerLevel + lowerOffset`)
   inline int lowerBound() const { return (lowerLevel_ + lowerOffset_); }
@@ -128,8 +142,16 @@ public:
     return sir::Interval(lowerLevel_, upperLevel_, lowerOffset_, upperOffset_);
   }
 
+  /// @brief returns true if the level bound of the interval is the end of the axis
+  bool levelIsEnd(Bound bound) const {
+    return (bound == Bound::lower) ? lowerLevelIsEnd() : upperLevelIsEnd();
+  }
+
+  /// @brief returns true if the lower bound of the interval is the end of the axis
+  bool lowerLevelIsEnd() const { return (lowerLevel_ == sir::Interval::End); }
+
   /// @brief returns true if the upper bound of the interval is the end of the axis
-  bool upperIsEnd() const { return (upperLevel_ == sir::Interval::End); }
+  bool upperLevelIsEnd() const { return (upperLevel_ == sir::Interval::End); }
 
   /// @brief Convert interval to string
   std::string toString() const;

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -124,8 +124,8 @@ public:
 
       // Register the variable
       instantiation_->setAccessIDNamePair(AccessID, returnVarName);
-      instantiation_->getStmtToAccessIDMap().emplace(newStmt, AccessID);
-      instantiation_->getExprToAccessIDMap().emplace(newExpr_, AccessID);
+      instantiation_->mapStmtToAccessID(newStmt, AccessID);
+      instantiation_->mapExprToAccessID(newExpr_, AccessID);
 
     } else {
       // We are called within an arugment list of a stencil function, we thus need to store the
@@ -141,7 +141,7 @@ public:
 
       // Promote the "temporary" storage we used to mock the argument to an actual temporary field
       instantiation_->setAccessIDNamePairOfField(AccessIDOfCaller_, returnFieldName, true);
-      instantiation_->getExprToAccessIDMap().emplace(newExpr_, AccessIDOfCaller_);
+      instantiation_->mapExprToAccessID(newExpr_, AccessIDOfCaller_);
     }
 
     // Resolve the actual expression of the return statement
@@ -161,7 +161,7 @@ public:
     int AccessID = curStencilFunctioninstantiation_->getAccessIDFromStmt(stmt);
     const std::string& name = curStencilFunctioninstantiation_->getNameFromAccessID(AccessID);
     instantiation_->setAccessIDNamePair(AccessID, name);
-    instantiation_->getStmtToAccessIDMap().emplace(stmt, AccessID);
+    instantiation_->mapStmtToAccessID(stmt, AccessID);
 
     // Push back the statement and move on
     appendNewStatementAccessesPair(stmt);
@@ -279,15 +279,15 @@ public:
 
   void visit(const std::shared_ptr<VarAccessExpr>& expr) override {
 
-    instantiation_->getExprToAccessIDMap().emplace(
-        expr, curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
+    instantiation_->mapExprToAccessID(expr,
+                                      curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
     if(expr->isArrayAccess())
       expr->getIndex()->accept(*this);
   }
 
   void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {
-    instantiation_->getExprToAccessIDMap().emplace(
-        expr, curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
+    instantiation_->mapExprToAccessID(expr,
+                                      curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
 
     // Set the fully evaluated offset as the new offset of the field. Note that this renders the
     // AST of the current stencil function incorrent which is why it needs to be removed!
@@ -300,7 +300,7 @@ public:
   void visit(const std::shared_ptr<LiteralAccessExpr>& expr) override {
     int AccessID = curStencilFunctioninstantiation_->getAccessIDFromExpr(expr);
     instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, expr->getValue());
-    instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+    instantiation_->mapExprToAccessID(expr, AccessID);
   }
 };
 

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -217,8 +217,8 @@ private:
     domethod->getStatementAccessesPairs().push_back(pair);
 
     // Add the new expressions to the map
-    instantiation_->getExprToAccessIDMap().emplace(fa_assignment, assignmentID);
-    instantiation_->getExprToAccessIDMap().emplace(fa_assignee, assigneeID);
+    instantiation_->mapExprToAccessID(fa_assignment, assignmentID);
+    instantiation_->mapExprToAccessID(fa_assignee, assigneeID);
   }
 
   /// @brief Checks if there is a read operation before the first write operation in the given

--- a/src/dawn/Optimizer/Replacing.cpp
+++ b/src/dawn/Optimizer/Replacing.cpp
@@ -78,8 +78,8 @@ void replaceFieldWithVarAccessInStmts(
 
       replaceOldExprWithNewExprInStmt(stmt, oldExpr, newExpr);
 
-      instantiation->getExprToAccessIDMap().emplace(newExpr, AccessID);
-      instantiation->getExprToAccessIDMap().erase(oldExpr);
+      instantiation->mapExprToAccessID(newExpr, AccessID);
+      instantiation->eraseExprToAccessID(oldExpr);
     }
   }
 }
@@ -101,8 +101,8 @@ void replaceVarWithFieldAccessInStmts(
 
       replaceOldExprWithNewExprInStmt(stmt, oldExpr, newExpr);
 
-      instantiation->getExprToAccessIDMap().emplace(newExpr, AccessID);
-      instantiation->getExprToAccessIDMap().erase(oldExpr);
+      instantiation->mapExprToAccessID(newExpr, AccessID);
+      instantiation->eraseExprToAccessID(oldExpr);
     }
   }
 }

--- a/src/dawn/Optimizer/Stage.cpp
+++ b/src/dawn/Optimizer/Stage.cpp
@@ -275,7 +275,7 @@ void Stage::update() {
 }
 
 bool Stage::hasGlobalVariables() const {
-  return (!globalVariables_.empty()) && (globalVariablesFromStencilFunctionCalls_.empty());
+  return (!globalVariables_.empty()) || (!globalVariablesFromStencilFunctionCalls_.empty());
 }
 
 const std::unordered_set<int>& Stage::getGlobalVariables() const { return globalVariables_; }

--- a/src/dawn/Optimizer/Stage.h
+++ b/src/dawn/Optimizer/Stage.h
@@ -51,7 +51,9 @@ class Stage {
   std::vector<Field> fields_;
 
   /// AccessIDs of the global variable accesses of this stage
+  std::unordered_set<int> allGlobalVariables_;
   std::unordered_set<int> globalVariables_;
+  std::unordered_set<int> globalVariablesFromStencilFunctionCalls_;
 
   Extents extents_;
 
@@ -125,10 +127,27 @@ public:
   /// the @b accumulated extent of each field
   void update();
 
+  /// @brief checks whether the stage contains global variables
+  bool hasGlobalVariables() const;
+
   /// @brief Get the global variables accessed in this stage
   ///
+  /// only returns those global variables used within the stage,
+  /// but not inside stencil functions called from the stage
   /// The global variables are computed during `Stage::update`.
   const std::unordered_set<int>& getGlobalVariables() const;
+
+  /// @brief Get the global variables accessed in stencil functions that
+  /// are called from within the stage
+  ///
+  /// The global variables are computed during `Stage::update`.
+  const std::unordered_set<int>& getGlobalVariablesFromStencilFunctionCalls() const;
+
+  /// @brief Get the all global variables used in the stage:
+  /// i.e. the union of getGlovalVariables() and getGlobalVariablesFromStencilFunctionCalls()
+  ///
+  /// The global variables are computed during `Stage::update`.
+  const std::unordered_set<int>& getAllGlobalVariables() const;
 
   /// @brief Add the given Do-Method to the list of Do-Methods of this stage
   ///

--- a/src/dawn/Optimizer/Stage.h
+++ b/src/dawn/Optimizer/Stage.h
@@ -51,7 +51,9 @@ class Stage {
   std::vector<Field> fields_;
 
   /// AccessIDs of the global variable accesses of this stage
+  std::unordered_set<int> allGlobalVariables_;
   std::unordered_set<int> globalVariables_;
+  std::unordered_set<int> globalVariablesFromStencilFunctionCalls_;
 
 public:
   /// @name Constructors and Assignment
@@ -123,10 +125,27 @@ public:
   /// the @b accumulated extent of each field
   void update();
 
+  /// @brief checks whether the stage contains global variables
+  bool hasGlobalVariables() const;
+
   /// @brief Get the global variables accessed in this stage
   ///
+  /// only returns those global variables used within the stage,
+  /// but not inside stencil functions called from the stage
   /// The global variables are computed during `Stage::update`.
   const std::unordered_set<int>& getGlobalVariables() const;
+
+  /// @brief Get the global variables accessed in stencil functions that
+  /// are called from within the stage
+  ///
+  /// The global variables are computed during `Stage::update`.
+  const std::unordered_set<int>& getGlobalVariablesFromStencilFunctionCalls() const;
+
+  /// @brief Get the all global variables used in the stage:
+  /// i.e. the union of getGlovalVariables() and getGlobalVariablesFromStencilFunctionCalls()
+  ///
+  /// The global variables are computed during `Stage::update`.
+  const std::unordered_set<int>& getAllGlobalVariables() const;
 
   /// @brief Add the given Do-Method to the list of Do-Methods of this stage
   ///

--- a/src/dawn/Optimizer/Stencil.cpp
+++ b/src/dawn/Optimizer/Stencil.cpp
@@ -137,10 +137,12 @@ std::vector<Stencil::FieldInfo> Stencil::getFields(bool withTemporaries) const {
 
 std::vector<std::string> Stencil::getGlobalVariables() const {
   std::set<int> globalVariableAccessIDs;
-  for(const auto& multistage : multistages_)
-    for(const auto& stage : multistage->getStages())
-      for(const auto& varAccessID : stage->getGlobalVariables())
-        globalVariableAccessIDs.insert(varAccessID);
+  for(const auto& multistage : multistages_) {
+    for(const auto& stage : multistage->getStages()) {
+      globalVariableAccessIDs.insert(stage->getAllGlobalVariables().begin(),
+                                     stage->getAllGlobalVariables().end());
+    }
+  }
 
   std::vector<std::string> globalVariables;
   for(const auto& AccessID : globalVariableAccessIDs)

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
@@ -41,7 +41,10 @@ StencilFunctionInstantiation::StencilFunctionInstantiation(
     sir::StencilFunction* function, const std::shared_ptr<AST>& ast, const Interval& interval,
     bool isNested)
     : stencilInstantiation_(context), expr_(expr), function_(function), ast_(ast),
-      interval_(interval), hasReturn_(false), isNested_(isNested) {}
+      interval_(interval), hasReturn_(false), isNested_(isNested) {
+  DAWN_ASSERT(context);
+  DAWN_ASSERT(function);
+}
 
 Array3i StencilFunctionInstantiation::evalOffsetOfFieldAccessExpr(
     const std::shared_ptr<FieldAccessExpr>& expr, bool applyInitialOffset) const {
@@ -265,24 +268,23 @@ int StencilFunctionInstantiation::getAccessIDFromStmt(const std::shared_ptr<Stmt
   return it->second;
 }
 
-const std::unordered_map<std::shared_ptr<Expr>, int>&
-StencilFunctionInstantiation::getExprToCallerAccessIDMap() const {
-  return ExprToCallerAccessIDMap_;
+void StencilFunctionInstantiation::setAccessIDOfExpr(const std::shared_ptr<Expr>& expr,
+                                                     const int accessID) {
+  ExprToCallerAccessIDMap_[expr] = accessID;
 }
 
-std::unordered_map<std::shared_ptr<Expr>, int>&
-StencilFunctionInstantiation::getExprToCallerAccessIDMap() {
-  return ExprToCallerAccessIDMap_;
+void StencilFunctionInstantiation::mapExprToAccessID(std::shared_ptr<Expr> expr, int accessID) {
+  ExprToCallerAccessIDMap_.emplace(expr, accessID);
 }
 
-const std::unordered_map<std::shared_ptr<Stmt>, int>&
-StencilFunctionInstantiation::getStmtToCallerAccessIDMap() const {
-  return StmtToCallerAccessIDMap_;
+void StencilFunctionInstantiation::setAccessIDOfStmt(const std::shared_ptr<Stmt>& stmt,
+                                                     const int accessID) {
+  DAWN_ASSERT(StmtToCallerAccessIDMap_.count(stmt));
+  StmtToCallerAccessIDMap_[stmt] = accessID;
 }
 
-std::unordered_map<std::shared_ptr<Stmt>, int>&
-StencilFunctionInstantiation::getStmtToCallerAccessIDMap() {
-  return StmtToCallerAccessIDMap_;
+void StencilFunctionInstantiation::mapStmtToAccessID(std::shared_ptr<Stmt> stmt, int accessID) {
+  StmtToCallerAccessIDMap_.emplace(stmt, accessID);
 }
 
 std::unordered_map<int, std::string>& StencilFunctionInstantiation::getLiteralAccessIDToNameMap() {

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
@@ -240,14 +240,22 @@ void StencilFunctionInstantiation::renameCallerAccessID(int oldAccessID, int new
 //     Expr/Stmt to Caller AccessID Maps
 //===----------------------------------------------------------------------------------------===//
 
-const std::string& StencilFunctionInstantiation::getNameFromAccessID(int AccessID) const {
+std::string StencilFunctionInstantiation::getNameFromAccessID(int AccessID) const {
   // As we store the caller accessIDs, we have to get the name of the field from the context!
   if(AccessID < 0)
     return getNameFromLiteralAccessID(AccessID);
-  else if(stencilInstantiation_->isField(AccessID))
+  else if(stencilInstantiation_->isField(AccessID) ||
+          stencilInstantiation_->isGlobalVariable(AccessID))
     return stencilInstantiation_->getNameFromAccessID(AccessID);
-  else
+  else {
+    DAWN_ASSERT(AccessIDToNameMap_.count(AccessID));
     return AccessIDToNameMap_.find(AccessID)->second;
+  }
+}
+
+void StencilFunctionInstantiation::setAccessIDOfGlobalVariable(int AccessID) {
+  //  setAccessIDNamePair(AccessID, name);
+  GlobalVariableAccessIDSet_.insert(AccessID);
 }
 
 const std::string& StencilFunctionInstantiation::getNameFromLiteralAccessID(int AccessID) const {

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
@@ -227,14 +227,22 @@ void StencilFunctionInstantiation::renameCallerAccessID(int oldAccessID, int new
 //     Expr/Stmt to Caller AccessID Maps
 //===----------------------------------------------------------------------------------------===//
 
-const std::string& StencilFunctionInstantiation::getNameFromAccessID(int AccessID) const {
+std::string StencilFunctionInstantiation::getNameFromAccessID(int AccessID) const {
   // As we store the caller accessIDs, we have to get the name of the field from the context!
   if(AccessID < 0)
     return getNameFromLiteralAccessID(AccessID);
-  else if(stencilInstantiation_->isField(AccessID))
+  else if(stencilInstantiation_->isField(AccessID) ||
+          stencilInstantiation_->isGlobalVariable(AccessID))
     return stencilInstantiation_->getNameFromAccessID(AccessID);
-  else
+  else {
+    DAWN_ASSERT(AccessIDToNameMap_.count(AccessID));
     return AccessIDToNameMap_.find(AccessID)->second;
+  }
+}
+
+void StencilFunctionInstantiation::setAccessIDOfGlobalVariable(int AccessID) {
+  //  setAccessIDNamePair(AccessID, name);
+  GlobalVariableAccessIDSet_.insert(AccessID);
 }
 
 const std::string& StencilFunctionInstantiation::getNameFromLiteralAccessID(int AccessID) const {

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.h
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.h
@@ -142,11 +142,45 @@ private:
   /// Set of AccessID of fields which are not used
   std::set<int> unusedFields_;
 
+  /// Set containing the AccessIDs of "global variable" accesses. Global variable accesses are
+  /// represented by global_accessor or if we know the value at compile time we do a constant
+  /// folding of the variable
+  std::set<int> GlobalVariableAccessIDSet_;
+
 public:
   StencilFunctionInstantiation(StencilInstantiation* context,
                                const std::shared_ptr<StencilFunCallExpr>& expr,
                                sir::StencilFunction* function, const std::shared_ptr<AST>& ast,
                                const Interval& interval, bool isNested);
+
+  std::unordered_map<int, int>& ArgumentIndexToCallerAccessIDMap() {
+    return ArgumentIndexToCallerAccessIDMap_;
+  }
+  std::unordered_map<int, int> const& ArgumentIndexToCallerAccessIDMap() const {
+    return ArgumentIndexToCallerAccessIDMap_;
+  }
+
+  size_t numArgs() const;
+
+  /// @brief register the access id of a global variable access
+  void setAccessIDOfGlobalVariable(int AccessID);
+
+  /// @brief get the access id set of a global variables
+  /// @{
+  std::set<int>& getAccessIDSetGlobalVariables() { return GlobalVariableAccessIDSet_; }
+  std::set<int> const& getAccessIDSetGlobalVariables() const { return GlobalVariableAccessIDSet_; }
+  /// @}
+
+  /// @brief get the name of the arg parameter of the stencil function which is called passing
+  /// another function
+  ///
+  /// In the following example
+  /// stencil_function fn {
+  ///   storage arg_st1, arg_st2;
+  /// }
+  /// fn(storage1, fn(storage2) )
+  /// it will return arg_st2
+  std::string getArgNameFromFunctionCall(std::string fnCallName) const;
 
   /// @brief Get the associated StencilInstantiation
   StencilInstantiation* getStencilInstantiation() { return stencilInstantiation_; }
@@ -242,7 +276,7 @@ public:
   //===----------------------------------------------------------------------------------------===//
 
   /// @brief Get the `name` associated with the `AccessID`
-  const std::string& getNameFromAccessID(int AccessID) const;
+  std::string getNameFromAccessID(int AccessID) const;
 
   /// @brief Get the `name` associated with the literal `AccessID`
   const std::string& getNameFromLiteralAccessID(int AccessID) const;

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.h
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.h
@@ -156,6 +156,11 @@ private:
   /// Set of AccessID of fields which are not used
   std::set<int> unusedFields_;
 
+  /// Set containing the AccessIDs of "global variable" accesses. Global variable accesses are
+  /// represented by global_accessor or if we know the value at compile time we do a constant
+  /// folding of the variable
+  std::set<int> GlobalVariableAccessIDSet_;
+
 public:
   StencilFunctionInstantiation(StencilInstantiation* context,
                                const std::shared_ptr<StencilFunCallExpr>& expr,
@@ -170,6 +175,15 @@ public:
   }
 
   size_t numArgs() const;
+
+  /// @brief register the access id of a global variable access
+  void setAccessIDOfGlobalVariable(int AccessID);
+
+  /// @brief get the access id set of a global variables
+  /// @{
+  std::set<int>& getAccessIDSetGlobalVariables() { return GlobalVariableAccessIDSet_; }
+  std::set<int> const& getAccessIDSetGlobalVariables() const { return GlobalVariableAccessIDSet_; }
+  /// @}
 
   /// @brief get the name of the arg parameter of the stencil function which is called passing
   /// another function
@@ -276,7 +290,7 @@ public:
   //===----------------------------------------------------------------------------------------===//
 
   /// @brief Get the `name` associated with the `AccessID`
-  const std::string& getNameFromAccessID(int AccessID) const;
+  std::string getNameFromAccessID(int AccessID) const;
 
   /// @brief Get the `name` associated with the literal `AccessID`
   const std::string& getNameFromLiteralAccessID(int AccessID) const;

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.h
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.h
@@ -171,6 +171,15 @@ public:
 
   size_t numArgs() const;
 
+  /// @brief get the name of the arg parameter of the stencil function which is called passing
+  /// another function
+  ///
+  /// In the following example
+  /// stencil_function fn {
+  ///   storage arg_st1, arg_st2;
+  /// }
+  /// fn(storage1, fn(storage2) )
+  /// it will return arg_st2
   std::string getArgNameFromFunctionCall(std::string fnCallName) const;
 
   /// @brief Get the associated StencilInstantiation

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.h
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.h
@@ -21,6 +21,7 @@
 #include "dawn/Optimizer/StatementAccessesPair.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/Array.h"
+#include "dawn/Support/Unreachable.h"
 #include <memory>
 #include <set>
 #include <string>
@@ -30,6 +31,19 @@
 namespace dawn {
 
 class StencilInstantiation;
+
+inline std::string dim2str(int dim) {
+  switch(dim) {
+  case 0:
+    return "i";
+  case 1:
+    return "j";
+  case 2:
+    return "k";
+  default:
+    dawn_unreachable("invalid dimension");
+  }
+};
 
 /// @brief Specific instantiation of a stencil function
 ///
@@ -147,6 +161,17 @@ public:
                                const std::shared_ptr<StencilFunCallExpr>& expr,
                                sir::StencilFunction* function, const std::shared_ptr<AST>& ast,
                                const Interval& interval, bool isNested);
+
+  std::unordered_map<int, int>& ArgumentIndexToCallerAccessIDMap() {
+    return ArgumentIndexToCallerAccessIDMap_;
+  }
+  std::unordered_map<int, int> const& ArgumentIndexToCallerAccessIDMap() const {
+    return ArgumentIndexToCallerAccessIDMap_;
+  }
+
+  size_t numArgs() const;
+
+  std::string getArgNameFromFunctionCall(std::string fnCallName) const;
 
   /// @brief Get the associated StencilInstantiation
   StencilInstantiation* getStencilInstantiation() { return stencilInstantiation_; }
@@ -334,7 +359,7 @@ public:
   const std::shared_ptr<StencilFunCallExpr>& getExpression() const { return expr_; }
 
   /// @brief Dump the stencil function instantiation to stdout
-  void dump();
+  void dump() const;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.h
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.h
@@ -253,13 +253,17 @@ public:
   /// @brief Get the `AccessID` of the Stmt (VarDeclStmt)
   int getAccessIDFromStmt(const std::shared_ptr<Stmt>& stmt) const;
 
-  /// @brief Get map which associates Exprs with `caller` AccessIDs
-  std::unordered_map<std::shared_ptr<Expr>, int>& getExprToCallerAccessIDMap();
-  const std::unordered_map<std::shared_ptr<Expr>, int>& getExprToCallerAccessIDMap() const;
+  /// @brief Set the `AccessID` of a Expr (VarAccess or FieldAccess)
+  void setAccessIDOfExpr(const std::shared_ptr<Expr>& expr, const int accessID);
 
-  /// @brief Get map which associates Stmts with `caller` AccessIDs
-  std::unordered_map<std::shared_ptr<Stmt>, int>& getStmtToCallerAccessIDMap();
-  const std::unordered_map<std::shared_ptr<Stmt>, int>& getStmtToCallerAccessIDMap() const;
+  /// @brief Add entry to the map between a given expr to its access ID
+  void mapExprToAccessID(std::shared_ptr<Expr> expr, int AccessID);
+
+  /// @brief Set the `AccessID` of a Stmt (VarDecl)
+  void setAccessIDOfStmt(const std::shared_ptr<Stmt>& stmt, const int accessID);
+
+  /// @brief Add entry to the map between a given stmt to its access ID
+  void mapStmtToAccessID(std::shared_ptr<Stmt> stmt, int AccessID);
 
   /// @brief Get the Literal-AccessID-to-Name map
   std::unordered_map<int, std::string>& getLiteralAccessIDToNameMap();

--- a/src/dawn/Optimizer/StencilInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilInstantiation.cpp
@@ -402,8 +402,6 @@ public:
       }
 
     } else {
-      DAWN_ASSERT(!function);
-
       // Register the mapping between VarAccessExpr and AccessID.
       if(function)
         function->mapExprToAccessID(expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);

--- a/src/dawn/Optimizer/StencilInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilInstantiation.cpp
@@ -199,7 +199,7 @@ public:
     auto& function = scope_.top()->FunctionInstantiation;
     if(function) {
       function->getAccessIDToNameMap().emplace(AccessID, globalName);
-      function->getStmtToCallerAccessIDMap().emplace(stmt, AccessID);
+      function->mapStmtToAccessID(stmt, AccessID);
     } else {
       instantiation_->setAccessIDNamePair(AccessID, globalName);
       instantiation_->getStmtToAccessIDMap().emplace(stmt, AccessID);
@@ -367,7 +367,6 @@ public:
     const auto& varname = expr->getName();
 
     if(expr->isExternal()) {
-      DAWN_ASSERT(!function);
       DAWN_ASSERT_MSG(!expr->isArrayAccess(), "global array access is not supported");
 
       const auto& value = instantiation_->getGlobalVariableValue(varname);
@@ -382,27 +381,34 @@ public:
 
         int AccessID = instantiation_->nextUID();
         instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, newExpr->getValue());
-        instantiation_->getExprToAccessIDMap().emplace(newExpr, AccessID);
+        instantiation_->mapExprToAccessID(newExpr, AccessID);
 
       } else {
+        StencilInstantiation* stencilInstantiation =
+            (function) ? function->getStencilInstantiation() : instantiation_;
+
         int AccessID = 0;
-        if(!instantiation_->isGlobalVariable(varname)) {
-          AccessID = instantiation_->nextUID();
-          instantiation_->setAccessIDNamePairOfGlobalVariable(AccessID, varname);
+        if(!stencilInstantiation->isGlobalVariable(varname)) {
+          AccessID = stencilInstantiation->nextUID();
+          stencilInstantiation->setAccessIDNamePairOfGlobalVariable(AccessID, varname);
         } else {
-          AccessID = instantiation_->getAccessIDFromName(varname);
+          AccessID = stencilInstantiation->getAccessIDFromName(varname);
         }
-        instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+
+        if(function)
+          function->mapExprToAccessID(expr, AccessID);
+        else
+          instantiation_->mapExprToAccessID(expr, AccessID);
       }
 
     } else {
+      DAWN_ASSERT(!function);
+
       // Register the mapping between VarAccessExpr and AccessID.
       if(function)
-        function->getExprToCallerAccessIDMap().emplace(
-            expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
+        function->mapExprToAccessID(expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
       else
-        instantiation_->getExprToAccessIDMap().emplace(
-            expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
+        instantiation_->mapExprToAccessID(expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
 
       // Resolve the index if this is an array access
       if(expr->isArrayAccess())
@@ -417,10 +423,10 @@ public:
     auto& function = scope_.top()->FunctionInstantiation;
     if(function) {
       function->getLiteralAccessIDToNameMap().emplace(AccessID, expr->getValue());
-      function->getExprToCallerAccessIDMap().emplace(expr, AccessID);
+      function->mapExprToAccessID(expr, AccessID);
     } else {
       instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, expr->getValue());
-      instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+      instantiation_->mapExprToAccessID(expr, AccessID);
     }
   }
 
@@ -430,9 +436,9 @@ public:
 
     auto& function = scope_.top()->FunctionInstantiation;
     if(function) {
-      function->getExprToCallerAccessIDMap().emplace(expr, AccessID);
+      function->mapExprToAccessID(expr, AccessID);
     } else {
-      instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+      instantiation_->mapExprToAccessID(expr, AccessID);
     }
 
     if(Scope* candiateScope = getCurrentCandidateScope()) {
@@ -686,7 +692,7 @@ public:
           auto voidStmt = std::make_shared<ExprStmt>(voidExpr);
           int AccessID = -instantiation_->nextUID();
           instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, "0");
-          instantiation_->getExprToAccessIDMap().emplace(voidExpr, AccessID);
+          instantiation_->mapExprToAccessID(voidExpr, AccessID);
           replaceOldStmtWithNewStmtInStmt(scope_.top()->Statements.back()->ASTStmt, stmt, voidStmt);
         }
       }
@@ -942,7 +948,7 @@ public:
 
         int AccessID = instantiation_->nextUID();
         instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, newExpr->getValue());
-        instantiation_->getExprToAccessIDMap().emplace(newExpr, AccessID);
+        instantiation_->mapExprToAccessID(newExpr, AccessID);
 
       } else {
         int AccessID = 0;
@@ -953,13 +959,12 @@ public:
           AccessID = instantiation_->getAccessIDFromName(varname);
         }
 
-        instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+        instantiation_->mapExprToAccessID(expr, AccessID);
       }
 
     } else {
       // Register the mapping between VarAccessExpr and AccessID.
-      instantiation_->getExprToAccessIDMap().emplace(
-          expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
+      instantiation_->mapExprToAccessID(expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
 
       // Resolve the index if this is an array access
       if(expr->isArrayAccess())
@@ -971,7 +976,7 @@ public:
     // Register a literal access (Note: the negative AccessID we assign!)
     int AccessID = -instantiation_->nextUID();
     instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, expr->getValue());
-    instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+    instantiation_->mapExprToAccessID(expr, AccessID);
   }
 
   void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {}
@@ -1054,15 +1059,6 @@ void StencilInstantiation::removeAccessID(int AccesssID) {
 
 const std::string& StencilInstantiation::getName() const { return SIRStencil_->Name; }
 
-const std::unordered_map<std::shared_ptr<Expr>, int>&
-StencilInstantiation::getExprToAccessIDMap() const {
-  return ExprToAccessIDMap_;
-}
-
-std::unordered_map<std::shared_ptr<Expr>, int>& StencilInstantiation::getExprToAccessIDMap() {
-  return ExprToAccessIDMap_;
-}
-
 const std::unordered_map<std::shared_ptr<Stmt>, int>&
 StencilInstantiation::getStmtToAccessIDMap() const {
   return StmtToAccessIDMap_;
@@ -1084,6 +1080,19 @@ const std::string& StencilInstantiation::getNameFromStageID(int StageID) const {
   auto it = StageIDToNameMap_.find(StageID);
   DAWN_ASSERT_MSG(it != StageIDToNameMap_.end(), "Invalid StageID");
   return it->second;
+}
+
+void StencilInstantiation::mapExprToAccessID(std::shared_ptr<Expr> expr, int accessID) {
+  ExprToAccessIDMap_.emplace(expr, accessID);
+}
+
+void StencilInstantiation::eraseExprToAccessID(std::shared_ptr<Expr> expr) {
+  DAWN_ASSERT(ExprToAccessIDMap_.count(expr));
+  ExprToAccessIDMap_.erase(expr);
+}
+
+void StencilInstantiation::mapStmtToAccessID(std::shared_ptr<Stmt> stmt, int accessID) {
+  StmtToAccessIDMap_.emplace(stmt, accessID);
 }
 
 const std::string& StencilInstantiation::getNameFromLiteralAccessID(int AccessID) const {
@@ -1353,6 +1362,18 @@ int StencilInstantiation::getAccessIDFromStmt(const std::shared_ptr<Stmt>& stmt)
   auto it = StmtToAccessIDMap_.find(stmt);
   DAWN_ASSERT_MSG(it != StmtToAccessIDMap_.end(), "Invalid Stmt");
   return it->second;
+}
+
+void StencilInstantiation::setAccessIDOfStmt(const std::shared_ptr<Stmt>& stmt,
+                                             const int accessID) {
+  DAWN_ASSERT(StmtToAccessIDMap_.count(stmt));
+  StmtToAccessIDMap_[stmt] = accessID;
+}
+
+void StencilInstantiation::setAccessIDOfExpr(const std::shared_ptr<Expr>& expr,
+                                             const int accessID) {
+  DAWN_ASSERT(ExprToAccessIDMap_.count(expr));
+  ExprToAccessIDMap_[expr] = accessID;
 }
 
 void StencilInstantiation::removeStencilFunctionInstantiation(

--- a/src/dawn/Optimizer/StencilInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilInstantiation.cpp
@@ -321,7 +321,6 @@ public:
           candiateScope->FunctionInstantiation->setCallerInitialOffsetFromAccessID(
               AccessID, Array3i{{0, 0, 0}});
           candiateScope->LocalFieldnameToAccessIDMap.emplace(field->Name, AccessID);
-
         } else {
           int AccessID = candiateScope->FunctionInstantiation->getCallerAccessIDOfArgField(argIdx);
           candiateScope->LocalFieldnameToAccessIDMap.emplace(field->Name, AccessID);
@@ -331,6 +330,11 @@ public:
     // Resolve the function
     scope_.push(scope_.top()->CandiateScopes.top());
     scope_.top()->FunctionInstantiation->getAST()->accept(*this);
+
+    for(auto id : stencilFun->getAccessIDSetGlobalVariables()) {
+      scope_.top()->LocalVarNameToAccessIDMap.emplace(stencilFun->getNameFromAccessID(id), id);
+    }
+
     scope_.pop();
 
     // We resolved the candiate function, move on ...
@@ -396,8 +400,12 @@ public:
         }
 
         if(function)
+          function->setAccessIDOfGlobalVariable(AccessID);
+
+        if(function) {
           function->mapExprToAccessID(expr, AccessID);
-        else
+          instantiation_->mapExprToAccessID(expr, AccessID);
+        } else
           instantiation_->mapExprToAccessID(expr, AccessID);
       }
 

--- a/src/dawn/Optimizer/StencilInstantiation.h
+++ b/src/dawn/Optimizer/StencilInstantiation.h
@@ -258,6 +258,12 @@ public:
   /// @brief Get the `AccessID` of the Expr (VarAccess or FieldAccess)
   int getAccessIDFromExpr(const std::shared_ptr<Expr>& expr) const;
 
+  /// @brief Set the `AccessID` of the Expr (VarAccess or FieldAccess)
+  void setAccessIDOfExpr(const std::shared_ptr<Expr>& expr, const int accessID);
+
+  /// @brief Set the `AccessID` of the Stmt (VarDeclStmt)
+  void setAccessIDOfStmt(const std::shared_ptr<Stmt>& stmt, const int accessID);
+
   /// @brief Get the `AccessID` of the Stmt (VarDeclStmt)
   int getAccessIDFromStmt(const std::shared_ptr<Stmt>& stmt) const;
 
@@ -267,6 +273,15 @@ public:
   const StencilFunctionInstantiation*
   getStencilFunctionInstantiation(const std::shared_ptr<StencilFunCallExpr>& expr) const;
 
+  /// @brief Add entry to the map between a given expr to its access ID
+  void mapExprToAccessID(std::shared_ptr<Expr> expr, int accessID);
+
+  /// @brief Add entry to the map between a given stmt to its access ID
+  void mapStmtToAccessID(std::shared_ptr<Stmt> stmt, int accessID);
+
+  /// @brief Add entry of the Expr to AccessID map
+  void eraseExprToAccessID(std::shared_ptr<Expr> expr);
+
   /// @brief Get StencilFunctionInstantiation of the `StencilFunCallExpr`
   std::unordered_map<std::shared_ptr<StencilFunCallExpr>, StencilFunctionInstantiation*>&
   getExprToStencilFunctionInstantiationMap();
@@ -275,7 +290,8 @@ public:
 
   /// @brief Remove the stencil function given by `expr`
   ///
-  /// If `callerStencilFunctionInstantiation` is not NULL (i.e the stencil function is called within
+  /// If `callerStencilFunctionInstantiation` is not NULL (i.e the stencil function is called
+  /// within
   /// the scope of another stencil function), the stencil function will be removed
   /// from the `callerStencilFunctionInstantiation` instead of this `StencilInstantiation`.
   void removeStencilFunctionInstantiation(
@@ -284,7 +300,8 @@ public:
 
   /// @brief Register a new stencil function
   ///
-  /// If `curStencilFunctionInstantiation` is not NULL, the stencil function is treated as a nested
+  /// If `curStencilFunctionInstantiation` is not NULL, the stencil function is treated as a
+  /// nested
   /// stencil function.
   StencilFunctionInstantiation*
   makeStencilFunctionInstantiation(const std::shared_ptr<StencilFunCallExpr>& expr,
@@ -317,10 +334,6 @@ public:
   getStencilFunctionInstantiations() const {
     return stencilFunctionInstantiations_;
   }
-
-  /// @brief Get map which associates Exprs with AccessIDs
-  std::unordered_map<std::shared_ptr<Expr>, int>& getExprToAccessIDMap();
-  const std::unordered_map<std::shared_ptr<Expr>, int>& getExprToAccessIDMap() const;
 
   /// @brief Get map which associates Stmts with AccessIDs
   std::unordered_map<std::shared_ptr<Stmt>, int>& getStmtToAccessIDMap();

--- a/src/dawn/Optimizer/StencilInstantiation.h
+++ b/src/dawn/Optimizer/StencilInstantiation.h
@@ -290,8 +290,7 @@ public:
 
   /// @brief Remove the stencil function given by `expr`
   ///
-  /// If `callerStencilFunctionInstantiation` is not NULL (i.e the stencil function is called
-  /// within
+  /// If `callerStencilFunctionInstantiation` is not NULL (i.e the stencil function is called within
   /// the scope of another stencil function), the stencil function will be removed
   /// from the `callerStencilFunctionInstantiation` instead of this `StencilInstantiation`.
   void removeStencilFunctionInstantiation(
@@ -300,8 +299,7 @@ public:
 
   /// @brief Register a new stencil function
   ///
-  /// If `curStencilFunctionInstantiation` is not NULL, the stencil function is treated as a
-  /// nested
+  /// If `curStencilFunctionInstantiation` is not NULL, the stencil function is treated as a nested
   /// stencil function.
   StencilFunctionInstantiation*
   makeStencilFunctionInstantiation(const std::shared_ptr<StencilFunCallExpr>& expr,

--- a/src/dawn/SIR/SIRSerializer.cpp
+++ b/src/dawn/SIR/SIRSerializer.cpp
@@ -12,18 +12,18 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
+#include "dawn/SIR/SIR.h"
 #include "dawn/SIR/AST.h"
 #include "dawn/SIR/ASTVisitor.h"
-#include "dawn/SIR/SIR.h"
 #include "dawn/SIR/SIR.pb.h"
 #include "dawn/SIR/SIRSerializer.h"
 #include "dawn/Support/Format.h"
-#include "dawn/Support/Unreachable.h"
 #include "dawn/Support/Logging.h"
+#include "dawn/Support/Unreachable.h"
 #include <fstream>
 #include <google/protobuf/util/json_util.h>
-#include <stack>
 #include <list>
+#include <stack>
 #include <tuple>
 
 namespace dawn {
@@ -444,7 +444,7 @@ static void setAST(sir::proto::AST* astProto, const AST* ast) {
 
 static std::string serializeImpl(const SIR* sir, SIRSerializer::SerializationKind kind) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
-  ProtobufLogger::init();  
+  ProtobufLogger::init();
 
   // Convert SIR to protobuf SIR
   sir::proto::SIR sirProto;
@@ -517,21 +517,23 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::SerializationKin
 
     sir::proto::GlobalVariableValue valueProto;
     valueProto.set_is_constexpr(value.isConstexpr());
-    switch(value.getType()) {
-    case sir::Value::Boolean:
-      valueProto.set_boolean_value(value.getValue<bool>());
-      break;
-    case sir::Value::Integer:
-      valueProto.set_integer_value(value.getValue<int>());
-      break;
-    case sir::Value::Double:
-      valueProto.set_double_value(value.getValue<double>());
-      break;
-    case sir::Value::String:
-      valueProto.set_string_value(value.getValue<std::string>());
-      break;
-    case sir::Value::None:
-      break;
+    if(!value.empty()) {
+      switch(value.getType()) {
+      case sir::Value::Boolean:
+        valueProto.set_boolean_value(value.getValue<bool>());
+        break;
+      case sir::Value::Integer:
+        valueProto.set_integer_value(value.getValue<int>());
+        break;
+      case sir::Value::Double:
+        valueProto.set_double_value(value.getValue<double>());
+        break;
+      case sir::Value::String:
+        valueProto.set_string_value(value.getValue<std::string>());
+        break;
+      case sir::Value::None:
+        break;
+      }
     }
 
     mapProto->insert({name, valueProto});
@@ -559,7 +561,7 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::SerializationKin
   default:
     dawn_unreachable("invalid SerializationKind");
   }
-  
+
   return str;
 }
 
@@ -884,7 +886,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str,
   GOOGLE_PROTOBUF_VERIFY_VERSION;
   using namespace sir;
   ProtobufLogger::init();
-  
+
   // Decode the string
   sir::proto::SIR sirProto;
   switch(kind) {
@@ -903,7 +905,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str,
   default:
     dawn_unreachable("invalid SerializationKind");
   }
-  
+
   // Convert protobuf SIR to SIR
   std::shared_ptr<SIR> sir = std::make_shared<SIR>();
 


### PR DESCRIPTION
DO NOT MERGE, JUST FOR REVIEW

Technical Description
==================
Support for one line nested function calls like
```fn(gn(i+1, st1, hn(st2, st3) ) ) ```

Changes: 
* Added a CodeGenProperties to hold all data structures that are used for stencils for code generation, instead of the, so far used, custom maps and vectors. 
* Add the extents of the stage as loop bounds of the naive backend