### PR TITLE
IIR refactor V

### DIFF
--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -41,23 +41,23 @@ void CodeGen::addTempStorageTypedef(Structure& stencilClass, iir::Stencil const&
 
 void CodeGen::addTmpStorageDeclaration(
     Structure& stencilClass,
-    IndexRange<const std::vector<iir::Stencil::FieldInfo>>& tempFields) const {
+    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const {
   if(!(tempFields.empty())) {
     stencilClass.addMember(tmpMetadataTypename_, tmpMetadataName_);
 
     for(auto field : tempFields)
-      stencilClass.addMember(tmpStorageTypename_, "m_" + (*field).Name);
+      stencilClass.addMember(tmpStorageTypename_, "m_" + (*field).second.Name);
   }
 }
 
 void CodeGen::addTmpStorageInit(
     MemberFunction& ctr, iir::Stencil const& stencil,
-    IndexRange<const std::vector<iir::Stencil::FieldInfo>>& tempFields) const {
+    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const {
   if(!(tempFields.empty())) {
     ctr.addInit(tmpMetadataName_ + "(dom_.isize(), dom_.jsize(), dom_.ksize() + 2*" +
                 std::to_string(getVerticalTmpHaloSize(stencil)) + ")");
     for(auto fieldIt : tempFields) {
-      ctr.addInit("m_" + (*fieldIt).Name + "(" + tmpMetadataName_ + ")");
+      ctr.addInit("m_" + (*fieldIt).second.Name + "(" + tmpMetadataName_ + ")");
     }
   }
 }

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -34,11 +34,12 @@ protected:
   size_t getVerticalTmpHaloSizeForMultipleStencils(
       const std::vector<std::unique_ptr<iir::Stencil>>& stencils) const;
   void addTempStorageTypedef(Structure& stencilClass, iir::Stencil const& stencil) const;
-  void
-  addTmpStorageDeclaration(Structure& stencilClass,
-                           IndexRange<const std::vector<iir::Stencil::FieldInfo>>& tmpFields) const;
-  void addTmpStorageInit(MemberFunction& ctr, const iir::Stencil& stencil,
-                         IndexRange<const std::vector<iir::Stencil::FieldInfo>>& tempFields) const;
+  void addTmpStorageDeclaration(
+      Structure& stencilClass,
+      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tmpFields) const;
+  void addTmpStorageInit(
+      MemberFunction& ctr, const iir::Stencil& stencil,
+      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const;
   void addTmpStorageInit_wrapper(MemberFunction& ctr,
                                  const std::vector<std::unique_ptr<iir::Stencil>>& stencils,
                                  const std::vector<std::string>& tempFields) const;

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -564,6 +564,7 @@ std::string GTCodeGen::generateStencilInstantiation(
                << ((!stage.hasGlobalVariables() && (accessorIdx == fields.size() - 1)) ? "" : ", ");
 
           arglist.push_back(std::move(paramName));
+          ++accessorIdx;
         }
 
         // Global accessor declaration

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -661,13 +661,11 @@ std::string GTCodeGen::generateStencilInstantiation(
 
     // Add static asserts to check halos against extents
     StencilConstructor.addComment("Check if extents do not exceed the halos");
-    std::unordered_map<int, iir::Extents> const& exts =
-        (*stencils[stencilIdx]).computeEnclosingAccessExtents();
     int i = 0;
     for(const auto& fieldPair : StencilFields) {
       const auto& fieldInfo = fieldPair.second;
       if(!fieldInfo.IsTemporary) {
-        auto const& ext = exts.at(fieldInfo.field.getAccessID());
+        auto const& ext = fieldInfo.field.getExtentsRB();
         // ===-----------------------------------------------------------------------------------===
         // PRODUCTIONTODO: [BADSTATICASSERTS]
         // Offset-Computation in K is currently broken and hence turned off. Remvove the -1 once it

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -70,7 +70,7 @@ private:
                                    const std::string& gridName) const;
   void
   buildPlaceholderDefinitions(MemberFunction& function,
-                              std::vector<iir::Stencil::FieldInfo> const& stencilFields,
+                              const std::unordered_map<int, iir::Stencil::FieldInfo>& stencilFields,
                               std::vector<std::string> const& stencilGlobalVariables,
                               std::vector<std::string> const& stencilConstructorTemplates) const;
 
@@ -83,15 +83,16 @@ private:
   bool isTemporary(iir::Stencil::FieldInfo const& f) const { return f.IsTemporary; }
 
   /// code generate sync methods statements for all the fields passed
-  void
-  generateSyncStorages(MemberFunction& method,
-                       const IndexRange<std::vector<iir::Stencil::FieldInfo>>& stencilFields) const;
+  void generateSyncStorages(
+      MemberFunction& method,
+      const IndexRange<std::unordered_map<int, iir::Stencil::FieldInfo>>& stencilFields) const;
 
   /// construct a string of template parameters for storages
   std::vector<std::string> buildFieldTemplateNames(
       IndexRange<std::vector<iir::Stencil::FieldInfo>> const& stencilFields) const;
 
-  int computeNumTemporaries(std::vector<iir::Stencil::FieldInfo> const& stencilFields) const;
+  int computeNumTemporaries(
+      std::unordered_map<int, iir::Stencil::FieldInfo> const& stencilFields) const;
 
   /// Maximum needed vector size of boost::fusion containers
   std::size_t mplContainerMaxSize_;

--- a/src/dawn/IIR/BlockStatements.cpp
+++ b/src/dawn/IIR/BlockStatements.cpp
@@ -41,9 +41,6 @@ BlockStatements BlockStatements::clone() const {
 }
 
 void BlockStatements::insert(std::unique_ptr<StatementAccessesPair>&& stmt) {
-  std::cout << "inser " << blockStatements_.size() << std::endl;
-  std::cout << "T" << static_cast<std::shared_ptr<Stmt>>(stmt->getStatement()->ASTStmt)
-            << std::endl;
   blockStatements_.push_back(std::move(stmt));
 }
 

--- a/src/dawn/IIR/CMakeLists.txt
+++ b/src/dawn/IIR/CMakeLists.txt
@@ -48,6 +48,8 @@ yoda_add_library(
           MultiInterval.h
           MultiStage.cpp 
           MultiStage.h
+          NodeUpdateType.cpp
+          NodeUpdateType.h
           Stage.cpp
           Stage.h
           StatementAccessesPair.cpp

--- a/src/dawn/IIR/DoMethod.cpp
+++ b/src/dawn/IIR/DoMethod.cpp
@@ -12,6 +12,9 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
+#include "dawn/IIR/IIR.h"
+#include "dawn/IIR/Stencil.h"
+#include "dawn/IIR/MultiStage.h"
 #include "dawn/IIR/DoMethod.h"
 #include "dawn/IIR/Stage.h"
 #include "dawn/IIR/Accesses.h"

--- a/src/dawn/IIR/DoMethod.h
+++ b/src/dawn/IIR/DoMethod.h
@@ -94,6 +94,8 @@ public:
   /// mergeWithDoInterval is true
   boost::optional<Interval> computeEnclosingAccessInterval(const int accessID,
                                                            const bool mergeWithDoInterval) const;
+
+  inline virtual void updateFromChildren() override {}
 };
 
 } // namespace iir

--- a/src/dawn/IIR/FieldAccessExtents.cpp
+++ b/src/dawn/IIR/FieldAccessExtents.cpp
@@ -31,7 +31,18 @@ void FieldAccessExtents::mergeWriteExtents(Extents const& extents) {
 
   updateTotalExtents();
 }
-
+// void FieldAccessExtents::expandReadExtents(Extents const& extents) {
+//  if(readAccessExtents_.is_initialized()) {
+//    readAccessExtents_->expand(extents);
+//    updateTotalExtents();
+//  }
+//}
+// void FieldAccessExtents::expandWriteExtents(Extents const& extents) {
+//  if(writeAccessExtents_.is_initialized()) {
+//    writeAccessExtents_->expand(extents);
+//    updateTotalExtents();
+//  }
+//}
 void FieldAccessExtents::mergeReadExtents(boost::optional<Extents> const& extents) {
   if(extents.is_initialized())
     mergeReadExtents(*extents);
@@ -39,6 +50,15 @@ void FieldAccessExtents::mergeReadExtents(boost::optional<Extents> const& extent
 void FieldAccessExtents::mergeWriteExtents(boost::optional<Extents> const& extents) {
   if(extents.is_initialized())
     mergeWriteExtents(*extents);
+}
+
+void FieldAccessExtents::setReadExtents(Extents const& extents) {
+  readAccessExtents_ = boost::make_optional(extents);
+  updateTotalExtents();
+}
+void FieldAccessExtents::setWriteExtents(Extents const& extents) {
+  writeAccessExtents_ = boost::make_optional(extents);
+  updateTotalExtents();
 }
 
 void FieldAccessExtents::updateTotalExtents() {

--- a/src/dawn/IIR/FieldAccessExtents.h
+++ b/src/dawn/IIR/FieldAccessExtents.h
@@ -45,6 +45,8 @@ public:
   void mergeWriteExtents(Extents const& extents);
   void mergeReadExtents(boost::optional<Extents> const& extents);
   void mergeWriteExtents(boost::optional<Extents> const& extents);
+  void setReadExtents(Extents const& extents);
+  void setWriteExtents(Extents const& extents);
 
 private:
   void updateTotalExtents();

--- a/src/dawn/IIR/MultiStage.cpp
+++ b/src/dawn/IIR/MultiStage.cpp
@@ -283,7 +283,9 @@ boost::optional<Interval> MultiStage::getEnclosingAccessIntervalTemporaries() co
   return interval;
 }
 
-std::unordered_map<int, Field> MultiStage::getFields() const {
+// TODO Do not use this
+
+std::unordered_map<int, Field> MultiStage::computeFieldsOnTheFly() const {
   std::unordered_map<int, Field> fields;
 
   for(const auto& stagePtr : children_) {
@@ -293,10 +295,12 @@ std::unordered_map<int, Field> MultiStage::getFields() const {
   return fields;
 }
 
-void MultiStage::update() {
+const std::unordered_map<int, Field>& MultiStage::getFields() const { return fields_; }
+
+void MultiStage::updateFromChildren() {
   fields_.clear();
   for(const auto& stagePtr : children_) {
-    mergeFields(stagePtr->getFields(), fields_);
+    mergeFields(stagePtr->getFields(), fields_, boost::make_optional(stagePtr->getExtents()));
   }
 }
 
@@ -311,7 +315,7 @@ void MultiStage::renameAllOccurrences(int oldAccessID, int newAccessID) {
                                doMethod.getChildren());
     }
 
-    stage.update();
+    stage.update(NodeUpdateType::levelAndTreeAbove);
   }
 }
 

--- a/src/dawn/IIR/MultiStage.cpp
+++ b/src/dawn/IIR/MultiStage.cpp
@@ -289,7 +289,7 @@ std::unordered_map<int, Field> MultiStage::computeFieldsOnTheFly() const {
   std::unordered_map<int, Field> fields;
 
   for(const auto& stagePtr : children_) {
-    mergeFields(stagePtr->getFields(), fields);
+    mergeFields(stagePtr->getFields(), fields, stagePtr->getExtents());
   }
 
   return fields;

--- a/src/dawn/IIR/MultiStage.cpp
+++ b/src/dawn/IIR/MultiStage.cpp
@@ -35,7 +35,7 @@ std::unique_ptr<MultiStage> MultiStage::clone() const {
   auto cloneMS = make_unique<MultiStage>(stencilInstantiation_, loopOrder_);
 
   cloneMS->caches_ = caches_;
-  cloneMS->fields_ = fields_;
+  cloneMS->derivedInfo_ = derivedInfo_;
 
   cloneMS->cloneChildrenFrom(*this);
   return cloneMS;
@@ -295,12 +295,13 @@ std::unordered_map<int, Field> MultiStage::computeFieldsOnTheFly() const {
   return fields;
 }
 
-const std::unordered_map<int, Field>& MultiStage::getFields() const { return fields_; }
+const std::unordered_map<int, Field>& MultiStage::getFields() const { return derivedInfo_.fields_; }
 
 void MultiStage::updateFromChildren() {
-  fields_.clear();
+  derivedInfo_.fields_.clear();
   for(const auto& stagePtr : children_) {
-    mergeFields(stagePtr->getFields(), fields_, boost::make_optional(stagePtr->getExtents()));
+    mergeFields(stagePtr->getFields(), derivedInfo_.fields_,
+                boost::make_optional(stagePtr->getExtents()));
   }
 }
 

--- a/src/dawn/IIR/MultiStage.h
+++ b/src/dawn/IIR/MultiStage.h
@@ -83,7 +83,7 @@ public:
   /// @brief Set the loop order
   void setLoopOrder(LoopOrderKind loopOrder) { loopOrder_ = loopOrder; }
 
-  void update();
+  virtual void updateFromChildren() override;
 
   /// @brief Index containing the information for splitting MultiStages
   ///
@@ -138,7 +138,9 @@ public:
   Interval getEnclosingInterval() const;
 
   /// @brief Get the pair <AccessID, field> for the fields used within the multi-stage
-  std::unordered_map<int, Field> getFields() const;
+  const std::unordered_map<int, Field>& getFields() const;
+
+  std::unordered_map<int, Field> computeFieldsOnTheFly() const;
 
   /// @brief Get the enclosing interval of all access to temporaries
   boost::optional<Interval> getEnclosingAccessIntervalTemporaries() const;

--- a/src/dawn/IIR/MultiStage.h
+++ b/src/dawn/IIR/MultiStage.h
@@ -52,7 +52,12 @@ class MultiStage : public IIRNode<Stencil, MultiStage, Stage, impl::StdList> {
 
   LoopOrderKind loopOrder_;
   std::unordered_map<int, iir::Cache> caches_;
-  std::unordered_map<int, Field> fields_;
+
+  struct DerivedInfo {
+    std::unordered_map<int, Field> fields_;
+  };
+
+  DerivedInfo derivedInfo_;
 
 public:
   static constexpr const char* name = "MultiStage";

--- a/src/dawn/IIR/NodeUpdateType.cpp
+++ b/src/dawn/IIR/NodeUpdateType.cpp
@@ -1,0 +1,14 @@
+#include "dawn/IIR/NodeUpdateType.h"
+
+namespace dawn {
+namespace iir {
+
+namespace impl {
+bool updateLevel(NodeUpdateType updateType) {
+  return static_cast<int>(updateType) < 2 && static_cast<int>(updateType) > -2;
+}
+bool updateTreeAbove(NodeUpdateType updateType) { return static_cast<int>(updateType) > 0; }
+bool updateTreeBelow(NodeUpdateType updateType) { return static_cast<int>(updateType) < 0; }
+} // namespace impl
+} // namespace iir
+} // namespace dawn

--- a/src/dawn/IIR/NodeUpdateType.h
+++ b/src/dawn/IIR/NodeUpdateType.h
@@ -12,7 +12,26 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/IIR/IIRNode.h"
+#ifndef DAWN_IIR_NODEUPDATETYPE_H
+#define DAWN_IIR_NODEUPDATETYPE_H
 
 namespace dawn {
-namespace iir {} // namespace dawn
+namespace iir {
+
+enum class NodeUpdateType : int {
+  treeAbove = 2,
+  levelAndTreeAbove = 1,
+  level = 0,
+  levelAndTreeBelow = -1,
+  treeBelow = -2
+};
+
+namespace impl {
+bool updateLevel(NodeUpdateType updateType);
+bool updateTreeAbove(NodeUpdateType updateType);
+bool updateTreeBelow(NodeUpdateType updateType);
+} // namespace impl
+} // namespace iir
+} // namespace dawn
+
+#endif

--- a/src/dawn/IIR/Stage.cpp
+++ b/src/dawn/IIR/Stage.cpp
@@ -27,21 +27,18 @@
 namespace dawn {
 namespace iir {
 
-Stage::Stage(StencilInstantiation& context, MultiStage* multiStage, int StageID)
-    : stencilInstantiation_(context), multiStage_(multiStage), StageID_(StageID),
-      extents_{0, 0, 0, 0, 0, 0} {}
+Stage::Stage(StencilInstantiation& context, int StageID)
+    : stencilInstantiation_(context), StageID_(StageID), extents_{0, 0, 0, 0, 0, 0} {}
 
-Stage::Stage(StencilInstantiation& context, MultiStage* multiStage, int StageID,
-             const Interval& interval)
-    : stencilInstantiation_(context), multiStage_(multiStage), StageID_(StageID),
-      extents_{0, 0, 0, 0, 0, 0} {
+Stage::Stage(StencilInstantiation& context, int StageID, const Interval& interval)
+    : stencilInstantiation_(context), StageID_(StageID), extents_{0, 0, 0, 0, 0, 0} {
   // TODO reconsider whether we want to insert an interval
   insertChild(make_unique<DoMethod>(interval));
 }
 
 std::unique_ptr<Stage> Stage::clone() const {
 
-  auto cloneStage = make_unique<Stage>(stencilInstantiation_, multiStage_, StageID_);
+  auto cloneStage = make_unique<Stage>(stencilInstantiation_, StageID_);
 
   cloneStage->fields_ = fields_;
   cloneStage->allGlobalVariables_ = allGlobalVariables_;
@@ -316,8 +313,6 @@ void Stage::appendDoMethod(DoMethodSmartPtr_t& from, DoMethodSmartPtr_t& to,
                      std::make_move_iterator(from->childrenEnd()));
 }
 
-LoopOrderKind Stage::getLoopOrder() const { return multiStage_->getLoopOrder(); }
-
 std::vector<std::unique_ptr<Stage>>
 Stage::split(std::deque<int>& splitterIndices,
              const std::deque<std::shared_ptr<DependencyGraphAccesses>>* graphs) {
@@ -337,8 +332,7 @@ Stage::split(std::deque<int>& splitterIndices,
     DoMethod::StatementAccessesIterator nextSplitterIndex =
         std::next(thisDoMethod.childrenBegin(), splitterIndices[i] + 1);
 
-    newStages.push_back(make_unique<Stage>(stencilInstantiation_, multiStage_,
-                                           stencilInstantiation_.nextUID(),
+    newStages.push_back(make_unique<Stage>(stencilInstantiation_, stencilInstantiation_.nextUID(),
                                            thisDoMethod.getInterval()));
     Stage& newStage = *newStages.back();
     DoMethod& doMethod = newStage.getSingleDoMethod();

--- a/src/dawn/IIR/Stage.cpp
+++ b/src/dawn/IIR/Stage.cpp
@@ -175,7 +175,8 @@ public:
   }
 };
 
-void Stage::update() {
+void Stage::updateLevel() {
+
   fields_.clear();
   globalVariables_.clear();
   globalVariablesFromStencilFunctionCalls_.clear();
@@ -280,8 +281,6 @@ void Stage::update() {
       fields_.at(accessPair.first).mergeReadExtents(accessPair.second);
     }
   }
-  // TODO
-  //  getParent()->update();
 }
 
 bool Stage::hasGlobalVariables() const {
@@ -303,7 +302,6 @@ void Stage::addDoMethod(const DoMethodSmartPtr_t& doMethod) {
       }) == childrenEnd(), "Do-Method with given interval already exists!");
 
   insertChild(doMethod->clone());
-  update();
 }
 
 void Stage::appendDoMethod(DoMethodSmartPtr_t& from, DoMethodSmartPtr_t& to,
@@ -316,7 +314,6 @@ void Stage::appendDoMethod(DoMethodSmartPtr_t& from, DoMethodSmartPtr_t& to,
   to->setDependencyGraph(dependencyGraph);
   to->insertChildren(to->childrenEnd(), std::make_move_iterator(from->childrenBegin()),
                      std::make_move_iterator(from->childrenEnd()));
-  update();
 }
 
 LoopOrderKind Stage::getLoopOrder() const { return multiStage_->getLoopOrder(); }
@@ -357,7 +354,7 @@ Stage::split(std::deque<int>& splitterIndices,
     //    for(std::size_t idx = prevSplitterIndex; idx < nextSplitterIndex; ++idx)
 
     // Update the fields of the new stage
-    newStage.update();
+    newStage.update(iir::NodeUpdateType::level);
 
     prevSplitterIndex = nextSplitterIndex;
   }

--- a/src/dawn/IIR/Stage.h
+++ b/src/dawn/IIR/Stage.h
@@ -45,7 +45,6 @@ class Stage : public IIRNode<MultiStage, Stage, DoMethod> {
   using base_type = IIRNode<MultiStage, Stage, DoMethod>;
 
   StencilInstantiation& stencilInstantiation_;
-  MultiStage* multiStage_;
 
   /// Unique identifier of the stage
   int StageID_;
@@ -69,9 +68,8 @@ public:
 
   /// @name Constructors and Assignment
   /// @{
-  Stage(StencilInstantiation& context, MultiStage* multiStage, int StageID,
-        const Interval& interval);
-  Stage(StencilInstantiation& context, MultiStage* multiStage, int StageID);
+  Stage(StencilInstantiation& context, int StageID, const Interval& interval);
+  Stage(StencilInstantiation& context, int StageID);
 
   //  Stage(const Stage&) = default;
   Stage(Stage&&) = default;
@@ -172,9 +170,6 @@ public:
   /// Calls `update()` in the end.
   void appendDoMethod(DoMethodSmartPtr_t& from, DoMethodSmartPtr_t& to,
                       const std::shared_ptr<DependencyGraphAccesses>& dependencyGraph);
-
-  /// @brief Get the loop order (induced by the multi-stage)
-  LoopOrderKind getLoopOrder() const;
 
   /// @brief Split the stage at the given indices into separate stages.
   ///

--- a/src/dawn/IIR/Stage.h
+++ b/src/dawn/IIR/Stage.h
@@ -49,16 +49,26 @@ class Stage : public IIRNode<MultiStage, Stage, DoMethod> {
   /// Unique identifier of the stage
   int StageID_;
 
-  /// Declaration of the fields of this stage
-  std::unordered_map<int, Field> fields_;
+  struct DerivedInfo {
 
-  /// AccessIDs of the global variable accesses of this stage
-  std::unordered_set<int> allGlobalVariables_;
-  std::unordered_set<int> globalVariables_;
-  std::unordered_set<int> globalVariablesFromStencilFunctionCalls_;
+    DerivedInfo() : extents_{0, 0, 0, 0, 0, 0} {}
+    DerivedInfo(DerivedInfo&&) = default;
+    DerivedInfo(const DerivedInfo&) = default;
+    DerivedInfo& operator=(DerivedInfo&&) = default;
+    DerivedInfo& operator=(const DerivedInfo&) = default;
 
-  // TODO move extents to derived
-  Extents extents_;
+    /// Declaration of the fields of this stage
+    std::unordered_map<int, Field> fields_;
+
+    /// AccessIDs of the global variable accesses of this stage
+    std::unordered_set<int> allGlobalVariables_;
+    std::unordered_set<int> globalVariables_;
+    std::unordered_set<int> globalVariablesFromStencilFunctionCalls_;
+
+    Extents extents_;
+  };
+
+  DerivedInfo derivedInfo_;
 
 public:
   static constexpr const char* name = "Stage";
@@ -129,7 +139,7 @@ public:
   /// `Input`
   ///
   /// The fields are computed during `Stage::update`.
-  const std::unordered_map<int, Field>& getFields() const { return fields_; }
+  const std::unordered_map<int, Field>& getFields() const { return derivedInfo_.fields_; }
 
   /// @brief Update the fields and global variables
   ///
@@ -186,8 +196,8 @@ public:
 
   /// @brief Get the extent of the stage
   /// @{
-  Extents const& getExtents() const { return extents_; }
-  void setExtents(Extents const& extents) { extents_ = extents; }
+  Extents const& getExtents() const { return derivedInfo_.extents_; }
+  void setExtents(Extents const& extents) { derivedInfo_.extents_ = extents; }
   /// @}
 
   /// @brief true if it contains no do methods or they are empty

--- a/src/dawn/IIR/Stage.h
+++ b/src/dawn/IIR/Stage.h
@@ -137,7 +137,7 @@ public:
   ///
   /// This recomputes the fields referenced in this Stage (and all its Do-Methods) and computes
   /// the @b accumulated extent of each field
-  void update();
+  virtual void updateLevel() override;
 
   /// @brief checks whether the stage contains global variables
   bool hasGlobalVariables() const;
@@ -191,15 +191,14 @@ public:
 
   /// @brief Get the extent of the stage
   /// @{
-  //  Extents& getExtents() { return extents_; }
-
   Extents const& getExtents() const { return extents_; }
   void setExtents(Extents const& extents) { extents_ = extents; }
-
   /// @}
 
   /// @brief true if it contains no do methods or they are empty
   bool isEmptyOrNullStmt() const;
+
+  inline virtual void updateFromChildren() override {}
 };
 
 } // namespace iir

--- a/src/dawn/IIR/StatementAccessesPair.h
+++ b/src/dawn/IIR/StatementAccessesPair.h
@@ -59,6 +59,9 @@ class StatementAccessesPair : public IIRNode<DoMethod, StatementAccessesPair, vo
 public:
   static constexpr const char* name = "StatementAccessesPair";
 
+  // TODO no need to have this with an SFINAE
+  inline virtual void updateFromChildren() override {}
+
   // TODO implement a print method per IIRNode and make the dump() use it
   explicit StatementAccessesPair(const std::shared_ptr<Statement>& statement);
 

--- a/src/dawn/IIR/Stencil.h
+++ b/src/dawn/IIR/Stencil.h
@@ -275,9 +275,6 @@ public:
   /// @brief Convert stencil to string (i.e print the list of multi-stage -> stages)
   friend std::ostream& operator<<(std::ostream& os, const Stencil& stencil);
 
-  /// @brief Method to compute and return the maximum extents for all the used accessors/fields
-  std::unordered_map<int, Extents> const computeEnclosingAccessExtents() const;
-
   /// @brief Get the pair <AccessID, field> for the fields used within the multi-stage
   const std::unordered_map<int, FieldInfo>& getFields() const { return derivedInfo_.fields_; }
 

--- a/src/dawn/IIR/Stencil.h
+++ b/src/dawn/IIR/Stencil.h
@@ -48,7 +48,10 @@ class Stencil : public IIRNode<IIR, Stencil, MultiStage, impl::StdList> {
   /// Dependency graph of the stages of this stencil
   std::shared_ptr<DependencyGraphStage> stageDependencyGraph_;
 
+  std::unordered_map<int, Field> fields_;
+
 public:
+  void prepre();
   static constexpr const char* name = "Stencil";
 
   using MultiStageSmartPtr_t = child_smartptr_t<MultiStage>;
@@ -273,7 +276,13 @@ public:
   std::unordered_map<int, Extents> const computeEnclosingAccessExtents() const;
 
   /// @brief Get the pair <AccessID, field> for the fields used within the multi-stage
-  std::unordered_map<int, Field> getFields2() const;
+  const std::unordered_map<int, Field>& getFields2() const { return fields_; }
+
+  std::unordered_map<int, Field> computeFieldsOnTheFly() const;
+
+  virtual void updateFromChildren() override;
+
+  bool compareDerivedInfo() const;
 
 private:
   void forEachStatementAccessesPairImpl(

--- a/src/dawn/IIR/Stencil.h
+++ b/src/dawn/IIR/Stencil.h
@@ -45,13 +45,15 @@ class Stencil : public IIRNode<IIR, Stencil, MultiStage, impl::StdList> {
   /// stencil with a stencil-call in the run() method
   int StencilID_;
 
-  /// Dependency graph of the stages of this stencil
-  std::shared_ptr<DependencyGraphStage> stageDependencyGraph_;
+  struct DerivedInfo {
+    /// Dependency graph of the stages of this stencil
+    std::shared_ptr<DependencyGraphStage> stageDependencyGraph_;
+    std::unordered_map<int, Field> fields_;
+  };
 
-  std::unordered_map<int, Field> fields_;
+  DerivedInfo derivedInfo_;
 
 public:
-  void prepre();
   static constexpr const char* name = "Stencil";
 
   using MultiStageSmartPtr_t = child_smartptr_t<MultiStage>;
@@ -169,8 +171,8 @@ public:
   /// @{
   /// //TODO no need to pass SIRStencil, we can get it from stencilInstantiation
   Stencil(StencilInstantiation& stencilInstantiation,
-          const std::shared_ptr<sir::Stencil>& SIRStencil, int StencilID,
-          const std::shared_ptr<DependencyGraphStage>& stageDependencyGraph = nullptr);
+          const std::shared_ptr<sir::Stencil>& SIRStencil, int StencilID /*,
+          const std::shared_ptr<DependencyGraphStage>& stageDependencyGraph = nullptr*/);
 
   Stencil(Stencil&&) = default;
 
@@ -276,7 +278,7 @@ public:
   std::unordered_map<int, Extents> const computeEnclosingAccessExtents() const;
 
   /// @brief Get the pair <AccessID, field> for the fields used within the multi-stage
-  const std::unordered_map<int, Field>& getFields2() const { return fields_; }
+  const std::unordered_map<int, Field>& getFields2() const { return derivedInfo_.fields_; }
 
   std::unordered_map<int, Field> computeFieldsOnTheFly() const;
 

--- a/src/dawn/IIR/StencilInstantiation.cpp
+++ b/src/dawn/IIR/StencilInstantiation.cpp
@@ -385,7 +385,7 @@ public:
     computeAccesses(instantiation_, doMethod.getChildren());
 
     // Now, we compute the fields of each stage (this will give us the IO-Policy of the fields)
-    stage->update();
+    stage->update(iir::NodeUpdateType::level);
 
     // Put the stage into a separate MultiStage ...
     multiStage->insertChild(std::move(stage));
@@ -614,6 +614,9 @@ StencilInstantiation::StencilInstantiation(::dawn::OptimizerContext* context,
   if(context_->getOptions().ReportAccesses)
     reportAccesses();
 
+  for(const auto& MS : iterateIIROver<MultiStage>(*IIR_)) {
+    MS->update(NodeUpdateType::levelAndTreeAbove);
+  }
   DAWN_LOG(INFO) << "Done initializing StencilInstantiation";
 }
 
@@ -828,7 +831,7 @@ int StencilInstantiation::createVersionAndRename(int AccessID, Stencil* stencil,
     }
 
     // Updat the fields of the stage
-    stage.update();
+    stage.update(iir::NodeUpdateType::level);
   }
 
   return newAccessID;

--- a/src/dawn/IIR/StencilInstantiation.cpp
+++ b/src/dawn/IIR/StencilInstantiation.cpp
@@ -360,7 +360,7 @@ public:
                              ? LoopOrderKind::LK_Forward
                              : LoopOrderKind::LK_Backward);
     std::unique_ptr<Stage> stage =
-        make_unique<Stage>(*instantiation_, multiStage.get(), instantiation_->nextUID(), interval);
+        make_unique<Stage>(*instantiation_, instantiation_->nextUID(), interval);
 
     DAWN_LOG(INFO) << "Processing vertical region at " << verticalRegion->Loc;
 

--- a/src/dawn/Optimizer/PassComputeStageExtents.cpp
+++ b/src/dawn/Optimizer/PassComputeStageExtents.cpp
@@ -12,6 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
+#include "dawn/IIR/IIRNodeIterator.h"
 #include "dawn/Optimizer/PassComputeStageExtents.h"
 #include "dawn/IIR/DependencyGraphStage.h"
 #include "dawn/Optimizer/OptimizerContext.h"
@@ -73,10 +74,17 @@ bool PassComputeStageExtents::run(
           // if found, add the (read) extent of the field as an extent of the stage
           iir::Extents ext = toStage.getExtents();
           ext.merge(fieldExtent);
+          // this pass is computing the redundant computation in the horizontal, therefore we
+          // nullify the vertical component of the stage
+          ext[2] = iir::Extent{0, 0};
           toStage.setExtents(ext);
         }
       }
     }
+  }
+
+  for(const auto& MS : iterateIIROver<iir::MultiStage>(*(stencilInstantiation->getIIR()))) {
+    MS->update(iir::NodeUpdateType::levelAndTreeAbove);
   }
 
   return true;

--- a/src/dawn/Optimizer/PassFieldVersioning.cpp
+++ b/src/dawn/Optimizer/PassFieldVersioning.cpp
@@ -116,6 +116,7 @@ bool PassFieldVersioning::run(
         iir::Stage& stage = (**stageRit);
         iir::DoMethod& doMethod = stage.getSingleDoMethod();
 
+        bool updateStage = false;
         // Iterate statements bottom -> top
         for(int stmtIndex = doMethod.getChildren().size() - 1; stmtIndex >= 0; --stmtIndex) {
           oldGraph = newGraph->clone();
@@ -135,7 +136,11 @@ bool PassFieldVersioning::run(
             // is invalid)
             newGraph = oldGraph;
             newGraph->insertStatementAccessesPair(stmtAccessesPair);
+            updateStage = true;
           }
+        }
+        if(updateStage) {
+          stage.update(iir::NodeUpdateType::levelAndTreeAbove);
         }
       }
       stageIdx--;

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -501,7 +501,10 @@ bool PassInlining::run(const std::shared_ptr<iir::StencilInstantiation>& stencil
       }
     }
 
-    stage.update();
+    stage.update(iir::NodeUpdateType::level);
+  }
+  for(const auto& MSPtr : iterateIIROver<iir::Stage>(*(stencilInstantiation->getIIR()))) {
+    MSPtr->update(iir::NodeUpdateType::levelAndTreeAbove);
   }
   return true;
 }

--- a/src/dawn/Optimizer/PassManager.cpp
+++ b/src/dawn/Optimizer/PassManager.cpp
@@ -53,6 +53,12 @@ bool PassManager::runPassOnStecilInstantiation(
 
   DAWN_ASSERT(instantiation->getIIR()->checkTreeConsistency());
 
+#ifndef NDEBUG
+  for(const auto& stencil : instantiation->getIIR()->getChildren()) {
+    DAWN_ASSERT(stencil->compareDerivedInfo());
+  }
+#endif
+
   DAWN_LOG(INFO) << "Done with " << pass->getName() << " : Success";
   return true;
 }

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -198,7 +198,7 @@ private:
     // Add the single do method to the new Stage
     assignmentStage->clearChildren();
     assignmentStage->addDoMethod(domethod);
-    assignmentStage->update();
+    assignmentStage->update(iir::NodeUpdateType::level);
 
     return assignmentStage;
   }

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -184,8 +184,8 @@ private:
                                                     const std::vector<int>& assignmentIDs,
                                                     const std::vector<int>& assigneeIDs) {
     // Add the cache Flush stage
-    std::unique_ptr<iir::Stage> assignmentStage = make_unique<iir::Stage>(
-        *instantiation_, multiStagePrt_.get(), instantiation_->nextUID(), interval);
+    std::unique_ptr<iir::Stage> assignmentStage =
+        make_unique<iir::Stage>(*instantiation_, instantiation_->nextUID(), interval);
     iir::Stage::DoMethodSmartPtr_t domethod = make_unique<iir::DoMethod>(interval);
     domethod->clearChildren();
 

--- a/src/dawn/Optimizer/PassStageMerger.cpp
+++ b/src/dawn/Optimizer/PassStageMerger.cpp
@@ -131,6 +131,7 @@ bool PassStageMerger::run(const std::shared_ptr<iir::StencilInstantiation>& sten
                   if(MergeStagesOfStencil) {
                     candidateStage.appendDoMethod(*curDoMethodIt, *candidateDoMethodIt,
                                                   newDepGraph);
+                    candidateStage.update(iir::NodeUpdateType::level);
                     mergedDoMethod = true;
 
                     // We moved one Do-Method away and thus broke our full axis
@@ -143,6 +144,7 @@ bool PassStageMerger::run(const std::shared_ptr<iir::StencilInstantiation>& sten
               // Interval does not exists in `candidateStage`, just insert our DoMethod
               if(MergeDoMethodsOfStencil && MergeDoMethodsOfStage) {
                 candidateStage.addDoMethod(*curDoMethodIt);
+                candidateStage.update(iir::NodeUpdateType::level);
                 mergedDoMethod = true;
                 break;
               }
@@ -162,7 +164,7 @@ bool PassStageMerger::run(const std::shared_ptr<iir::StencilInstantiation>& sten
         }
 
         if(updateFields)
-          curStage.update();
+          curStage.update(iir::NodeUpdateType::level);
         curStageIt++;
       }
 

--- a/src/dawn/Optimizer/PassStageReordering.cpp
+++ b/src/dawn/Optimizer/PassStageReordering.cpp
@@ -54,7 +54,10 @@ bool PassStageReordering::run(
 
     // TODO should we have Iterators so to prevent unique_ptr swaps
     auto newStencil = strategy->reorder(stencilPtr);
+
     stencilInstantiation->getIIR()->replace(stencilPtr, newStencil, stencilInstantiation->getIIR());
+
+    stencilPtr->update(iir::NodeUpdateType::levelAndTreeAbove);
 
     if(!stencilPtr)
       return false;

--- a/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -107,12 +107,16 @@ bool PassStageSplitter::run(
         } else {
           DAWN_ASSERT(graphs.size() == 1);
           doMethod.setDependencyGraph(graphs.back());
-          stage.update();
+          stage.update(iir::NodeUpdateType::level);
           ++stageIt;
         }
       }
 
       multiStageIndex += 1;
+    }
+
+    for(const auto& multiStage : stencil->getChildren()) {
+      multiStage->update(iir::NodeUpdateType::levelAndTreeAbove);
     }
   }
 

--- a/src/dawn/Optimizer/PassTemporaryToStencilFunction.cpp
+++ b/src/dawn/Optimizer/PassTemporaryToStencilFunction.cpp
@@ -531,7 +531,7 @@ bool PassTemporaryToStencilFunction::run(
           }
         }
         if(isATmpReplaced) {
-          stagePtr->update();
+          stagePtr->update(iir::NodeUpdateType::level);
         }
       }
 
@@ -555,6 +555,9 @@ bool PassTemporaryToStencilFunction::run(
     for(const auto& multiStage : stencilPtr->getChildren()) {
       multiStage->childrenEraseIf(
           [](const std::unique_ptr<iir::Stage>& s) -> bool { return s->isEmptyOrNullStmt(); });
+    }
+    for(const auto& multiStage : stencilPtr->getChildren()) {
+      multiStage->update(iir::NodeUpdateType::levelAndTreeAbove);
     }
   }
 

--- a/src/dawn/Optimizer/PassTemporaryType.cpp
+++ b/src/dawn/Optimizer/PassTemporaryType.cpp
@@ -77,7 +77,7 @@ struct Temporary {
   int AccessID;                    ///< AccessID of the field or variable
   TemporaryType Type : 1;          ///< Type of the temporary
   iir::Stencil::Lifetime Lifetime; ///< Lifetime of the temporary
-  iir::Extents Extent;                  ///< Accumulated access of the temporary during its lifetime
+  iir::Extents Extent;             ///< Accumulated access of the temporary during its lifetime
 
   /// @brief Dump the temporary
   void dump(const std::shared_ptr<iir::StencilInstantiation>& instantiation) const {
@@ -190,18 +190,20 @@ void PassTemporaryType::fixTemporariesSpanningMultipleStencils(
     return;
 
   for(int i = 0; i < stencils.size(); ++i) {
-    for(const iir::Stencil::FieldInfo& fieldi : stencils[i]->getFields()) {
+    for(const auto& fieldi : stencils[i]->getFields()) {
 
       // Is fieldi a temporary?
-      if(fieldi.IsTemporary) {
+      if(fieldi.second.IsTemporary) {
 
         // Is it referenced in another stencil?
         for(int j = i + 1; j < stencils.size(); ++j) {
-          for(const iir::Stencil::FieldInfo& fieldj : stencils[j]->getFields()) {
+          for(const auto& fieldj : stencils[j]->getFields()) {
 
             // Yes and yes ... promote it to a real storage
-            if(fieldi.AccessID == fieldj.AccessID && fieldj.IsTemporary) {
-              instantiation->promoteTemporaryFieldToAllocatedField(fieldi.AccessID);
+            if(fieldi.second.field.getAccessID() == fieldj.second.field.getAccessID() &&
+               fieldj.second.IsTemporary) {
+              instantiation->promoteTemporaryFieldToAllocatedField(
+                  fieldi.second.field.getAccessID());
             }
           }
         }

--- a/src/dawn/Optimizer/ReorderStrategyGreedy.cpp
+++ b/src/dawn/Optimizer/ReorderStrategyGreedy.cpp
@@ -29,8 +29,8 @@ namespace dawn {
 
 /// @brief Check if we can merge the stage into the multi-stage, possibly changing the loop order.
 /// @returns the the enew dependency graphs of the multi-stage (or NULL) and the new loop order
-template <
-    typename ReturnType = std::pair<std::shared_ptr<iir::DependencyGraphAccesses>, iir::LoopOrderKind>>
+template <typename ReturnType =
+              std::pair<std::shared_ptr<iir::DependencyGraphAccesses>, iir::LoopOrderKind>>
 ReturnType isMergable(const iir::Stage& stage, iir::LoopOrderKind stageLoopOrder,
                       const iir::MultiStage& multiStage) {
   iir::LoopOrderKind multiStageLoopOrder = multiStage.getLoopOrder();
@@ -183,7 +183,7 @@ ReoderStrategyGreedy::reorder(const std::unique_ptr<iir::Stencil>& stencilPtr) {
       it++;
   }
 
-  return std::move(newStencil);
+  return newStencil;
 }
 
 } // namespace dawn

--- a/src/dawn/Optimizer/ReorderStrategyGreedy.cpp
+++ b/src/dawn/Optimizer/ReorderStrategyGreedy.cpp
@@ -91,8 +91,9 @@ ReoderStrategyGreedy::reorder(const std::unique_ptr<iir::Stencil>& stencilPtr) {
   iir::StencilInstantiation& instantiation = stencil.getStencilInstantiation();
 
   std::unique_ptr<iir::Stencil> newStencil =
-      make_unique<iir::Stencil>(instantiation, stencil.getSIRStencil(), stencilPtr->getStencilID(),
-                                stencil.getStageDependencyGraph());
+      make_unique<iir::Stencil>(instantiation, stencil.getSIRStencil(), stencilPtr->getStencilID());
+
+  newStencil->setStageDependencyGraph(stencil.getStageDependencyGraph());
   int newNumStages = 0;
   int newNumMultiStages = 0;
 

--- a/test/unit-test/dawn/Optimizer/Passes/TestComputeMaxExtent.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestComputeMaxExtent.cpp
@@ -69,14 +69,14 @@ TEST_F(ComputeMaxExtents, test_stencil_01) {
   const std::unique_ptr<iir::Stencil>& stencil = stencils[0];
 
   ASSERT_TRUE((stencil->getNumStages() == 2));
-  auto exts = stencil->computeEnclosingAccessExtents();
+  auto exts = stencil->getFields();
   EXPECT_EQ(exts.size(), 3);
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(1)), "u");
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(2)), "out");
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(3)), "lap");
-  EXPECT_EQ(exts.at(1), (iir::Extents{-2, 2, -2, 2, 0, 0}));
-  EXPECT_EQ(exts.at(2), (iir::Extents{0, 0, 0, 0, 0, 0}));
-  EXPECT_EQ(exts.at(3), (iir::Extents{-1, 1, -1, 1, 0, 0}));
+  EXPECT_EQ(exts.at(1).field.getExtentsRB(), (iir::Extents{-2, 2, -2, 2, 0, 0}));
+  EXPECT_EQ(exts.at(2).field.getExtentsRB(), (iir::Extents{0, 0, 0, 0, 0, 0}));
+  EXPECT_EQ(exts.at(3).field.getExtentsRB(), (iir::Extents{-1, 1, -1, 1, 0, 0}));
 }
 
 TEST_F(ComputeMaxExtents, test_stencil_02) {
@@ -86,14 +86,14 @@ TEST_F(ComputeMaxExtents, test_stencil_02) {
   const std::unique_ptr<iir::Stencil>& stencil = stencils[0];
 
   ASSERT_TRUE((stencil->getNumStages() == 3));
-  auto exts = stencil->computeEnclosingAccessExtents();
+  auto exts = stencil->getFields();
   EXPECT_EQ(exts.size(), 6);
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(1)), "u");
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(2)), "out");
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(3)), "coeff");
-  EXPECT_EQ(exts.at(1), (iir::Extents{-2, 2, -2, 2, 0, 0}));
-  EXPECT_EQ(exts.at(2), (iir::Extents{0, 0, 0, 0, 0, 0}));
-  EXPECT_EQ(exts.at(3), (iir::Extents{0, 0, 0, 0, 0, 0}));
+  EXPECT_EQ(exts.at(1).field.getExtentsRB(), (iir::Extents{-2, 2, -2, 2, 0, 0}));
+  EXPECT_EQ(exts.at(2).field.getExtentsRB(), (iir::Extents{0, 0, 0, 0, 0, 0}));
+  EXPECT_EQ(exts.at(3).field.getExtentsRB(), (iir::Extents{0, 0, 0, 0, 0, 0}));
 }
 TEST_F(ComputeMaxExtents, test_stencil_03) {
   std::unique_ptr<iir::IIR> IIR = loadTest("compute_extent_test_stencil_03.sir");
@@ -102,14 +102,14 @@ TEST_F(ComputeMaxExtents, test_stencil_03) {
   const std::unique_ptr<iir::Stencil>& stencil = stencils[0];
 
   ASSERT_TRUE((stencil->getNumStages() == 4));
-  auto exts = stencil->computeEnclosingAccessExtents();
+  auto exts = stencil->getFields();
   EXPECT_EQ(exts.size(), 7);
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(1)), "u");
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(2)), "out");
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(3)), "coeff");
-  EXPECT_EQ(exts.at(1), (iir::Extents{-2, 2, -2, 3, 0, 0}));
-  EXPECT_EQ(exts.at(2), (iir::Extents{0, 0, 0, 0, 0, 0}));
-  EXPECT_EQ(exts.at(3), (iir::Extents{0, 0, 0, 1, 0, 0}));
+  EXPECT_EQ(exts.at(1).field.getExtentsRB(), (iir::Extents{-2, 2, -2, 3, 0, 0}));
+  EXPECT_EQ(exts.at(2).field.getExtentsRB(), (iir::Extents{0, 0, 0, 0, 0, 0}));
+  EXPECT_EQ(exts.at(3).field.getExtentsRB(), (iir::Extents{0, 0, 0, 1, 0, 0}));
 }
 
 TEST_F(ComputeMaxExtents, test_stencil_04) {
@@ -120,12 +120,12 @@ TEST_F(ComputeMaxExtents, test_stencil_04) {
   const std::unique_ptr<iir::Stencil>& stencil = stencils[0];
 
   ASSERT_TRUE((stencil->getNumStages() == 4));
-  auto exts = stencil->computeEnclosingAccessExtents();
+  auto exts = stencil->getFields();
   EXPECT_EQ(exts.size(), 6);
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(1)), "u");
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(2)), "out");
-  EXPECT_EQ(exts.at(1), (iir::Extents{-3, 4, -2, 1, 0, 0}));
-  EXPECT_EQ(exts.at(2), (iir::Extents{0, 0, 0, 0, 0, 0}));
+  EXPECT_EQ(exts.at(1).field.getExtentsRB(), (iir::Extents{-3, 4, -2, 1, 0, 0}));
+  EXPECT_EQ(exts.at(2).field.getExtentsRB(), (iir::Extents{0, 0, 0, 0, 0, 0}));
 }
 
 TEST_F(ComputeMaxExtents, test_stencil_05) {
@@ -136,12 +136,12 @@ TEST_F(ComputeMaxExtents, test_stencil_05) {
   const std::unique_ptr<iir::Stencil>& stencil = stencils[0];
 
   ASSERT_TRUE((stencil->getNumStages() == 4));
-  auto exts = stencil->computeEnclosingAccessExtents();
+  auto exts = stencil->getFields();
   EXPECT_EQ(exts.size(), 6);
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(1)), "u");
   EXPECT_EQ((stencil->getStencilInstantiation().getNameFromAccessID(2)), "out");
-  EXPECT_EQ(exts.at(1), (iir::Extents{-3, 4, -2, 1, 0, 0}));
-  EXPECT_EQ(exts.at(2), (iir::Extents{0, 0, 0, 0, 0, 0}));
+  EXPECT_EQ(exts.at(1).field.getExtentsRB(), (iir::Extents{-3, 4, -2, 1, 0, 0}));
+  EXPECT_EQ(exts.at(2).field.getExtentsRB(), (iir::Extents{0, 0, 0, 0, 0, 0}));
 }
 
 } // anonymous namespace

--- a/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
@@ -169,7 +169,7 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_05) {
   const std::unique_ptr<iir::Stencil>& stencil = stencils[0];
 
   EXPECT_EQ(stencil->getNumStages(), 2);
-  EXPECT_EQ(stencil->getStage(0)->getExtents(), (iir::Extents{-1, 1, -1, 1, -1, 0}));
+  EXPECT_EQ(stencil->getStage(0)->getExtents(), (iir::Extents{-1, 1, -1, 1, 0, 0}));
   EXPECT_EQ(stencil->getStage(1)->getExtents(), (iir::Extents{0, 0, 0, 0, 0, 0}));
 
   for(auto fieldPair : (*stencil->childrenBegin())->getFields()) {


### PR DESCRIPTION
Technical Description
=================

* implement DerivedInfo structures for each level of the IIR tree
* implement update methods to propagate the computation of the derived info that depends on other levels. Each node should provide the following functions: 
 - `updateLevel` computes the derived info of the level from exclusively information of this level. See Stage::updateLevel
 - `updateFromChildren`  computes the derived info of the level that depends on derived info of lower levels of the tree
 - `IIRNode::update()` is the main API method to trigger the update of the derived info, which accepts a tag that identifies whether the update should propagate to parents or children or just the node itself. 
Notice that not all the derived info is compute with the update nor propagate. For the moment it is mainly the information related to the Fields. Other like the extents of the Stage are still computed by the corresponding Pass. 
- A typical pattern is the following, within a pass that modifies stmts, within the loop of the stages we update stage (node level only). That means the derived info is not up to date for the whole tree, since we have modified at the stage level but not above. That is ok though, since we are not using that updated derived info within the pass (it just relies on IIR or before pass derived info). 
Then, before closing the pass, we will trigger the update of the MS derived info, an above.

See for example
https://github.com/cosunae/dawn/pull/11/files#diff-b6ba778da7d1f730708cbd926e575f8cL504